### PR TITLE
Add availability to Item type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `availability` field to the `Item` GraphQL type.
+
 ## [0.8.2] - 2019-09-05
 
 ## Fixed

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -1,5 +1,6 @@
 type Item {
   additionalInfo: ItemAdditionalInfo
+  availability: String
   detailUrl: String
   id: ID
   imageUrl: String


### PR DESCRIPTION
#### What problem is this solving?

This adds the `availability` field to the `Item` type in GraphQL responses.

#### How should this be manually tested?

Make the following query
```graphql
query orderForm {
  orderForm {
    items {
      availability
    }
  }
}
```
And verify the data is returned as expected.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/19008/tratar-produtos-indisponíveis).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
