### PR TITLE
Use images with fixed weight and variable height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Image height is not fixed to 96 pixels anymore.
+
 ## [0.10.0] - 2019-09-12
 
-## Added
+### Added
 
-- `messages` field to `OrderForm`
-- `marketingData` field resolver
-- `OrderForm` messages being mapped to the proper Checkout OrderForm message fields
+- `messages` field to `OrderForm`;
+- `marketingData` field resolver;
+- `OrderForm` messages being mapped to the proper Checkout OrderForm message fields.
 
 ## [0.9.0] - 2019-09-05
 
@@ -23,19 +27,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.2] - 2019-09-05
 
-## Fixed
+### Fixed
 
 - OrderForm's `marketingData` now can not be null.
 
 ## [0.8.1] - 2019-09-05
 
-## Changed
+### Changed
 
-- insertCoupon returns the entire OrderForm
+- insertCoupon returns the entire OrderForm.
 
 ## [0.8.0] - 2019-09-04
 
-## Added
+### Added
 
 - `estimateShipping` mutation to calculate delivery options;
 - `getNewOrderForm` to unify getting and returning a new orderForm;

--- a/node/utils/image.ts
+++ b/node/utils/image.ts
@@ -1,5 +1,4 @@
 const DEFAULT_WIDTH = 96
-const DEFAULT_HEIGHT = 96
 const DEFAULT_HDF = 1
 
 const baseUrlRegex = new RegExp(/.+ids\/(\d+)(?:-(\d+)-(\d+)|)\//)
@@ -26,17 +25,14 @@ const cleanImageUrl = (imageUrl: string) => {
 const changeImageUrlSize = (
   imageUrl: string | undefined,
   width = DEFAULT_WIDTH,
-  height = DEFAULT_HEIGHT,
   highDensityFactor = DEFAULT_HDF
 ) => {
-  // imageUrl example http://omniera.vteximg.com.br/arquivos/ids/155401-135-135/CAN-09-04--1-.jpg
-  if (!imageUrl || !width || !height) {
+  if (!imageUrl) {
     return undefined
   }
   const widthCalc = width * highDensityFactor
-  const heightCalc = height * highDensityFactor
   const resizedImageUrl = imageUrl.slice(0, -1) // Remove last "/"
-  return `${resizedImageUrl}-${widthCalc}-${heightCalc}`
+  return `${resizedImageUrl}-${widthCalc}-auto`
 }
 
 const replaceHttpToRelativeProtocol = (url: string | undefined) => {


### PR DESCRIPTION
#### What problem is this solving?

We were always sending to the front-end images in 96x96 size, regardless of the original image's size.

This PR changes this behavior by fixing the width to 96 but maintaining the original image's aspect ratio.

#### How should this be manually tested?

[Workspace](https://image--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/18353/exibir-imagens-com-largura-fixa-e-altura-variavel).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/8902498/64825523-efb47280-d593-11e9-82f2-e8ed3afe1472.png)

After:
![image](https://user-images.githubusercontent.com/8902498/64825535-f9d67100-d593-11e9-9e08-e31b5b3c97eb.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
