### PR TITLE
Use search-graphql instead of store-graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `search-graphql` is used instead of `store-graphql` for the `product` query.
+
 ## [0.10.1] - 2019-09-13
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "node": "4.x"
   },
   "dependencies": {
-    "vtex.store-graphql": "2.x"
+    "vtex.search-graphql": "0.x"
   },
   "credentialType": "absolute",
   "mustUpdateAt": "2019-11-05",
@@ -25,7 +25,7 @@
       }
     },
     {
-      "name": "vtex.store-graphql:resolve-graphql"
+      "name": "vtex.search-graphql:resolve-graphql"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -265,10 +265,10 @@ export class Checkout extends JanusClient {
         `${base}/orders/${orderFormId}/user-cancel-request`,
       checkin: (orderFormId: string) =>
         `${base}/orderForm/${orderFormId}/checkIn`,
-      insertCoupon: (orderFormId: string) =>
-        `${base}/orderForm/${orderFormId}/coupons`,
       clearMessages: (orderFormId: string) =>
         `${base}/orderForm/${orderFormId}/messages/clear`,
+      insertCoupon: (orderFormId: string) =>
+        `${base}/orderForm/${orderFormId}/coupons`,
       orderForm: `${base}/orderForm`,
       orderFormCustomData: (
         orderFormId: string,

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,16 +1,16 @@
 import { IOClients } from '@vtex/api'
 
 import { Checkout } from './checkout'
+import { SearchGraphQL } from './searchGraphQL'
 import { Shipping } from './shipping'
-import { StoreGraphQL } from './storeGraphQL'
 
 export class Clients extends IOClients {
   public get checkout() {
     return this.getOrSet('checkout', Checkout)
   }
 
-  public get storeGraphQL() {
-    return this.getOrSet('storeGraphQL', StoreGraphQL)
+  public get searchGraphQL() {
+    return this.getOrSet('searchGraphQL', SearchGraphQL)
   }
 
   public get shipping() {

--- a/node/clients/searchGraphQL/index.ts
+++ b/node/clients/searchGraphQL/index.ts
@@ -2,9 +2,9 @@ import { AppGraphQLClient, InstanceOptions, IOContext, Serializable } from '@vte
 
 import { ProductArgs, ProductResponse, query as productQuery } from './productQuery'
 
-export class StoreGraphQL extends AppGraphQLClient {
+export class SearchGraphQL extends AppGraphQLClient {
   constructor(ctx: IOContext, opts?: InstanceOptions) {
-    super('vtex.store-graphql', ctx, opts)
+    super('vtex.search-graphql', ctx, opts)
   }
 
   public product = <T extends Serializable = ProductResponse>(

--- a/node/clients/searchGraphQL/productQuery.ts
+++ b/node/clients/searchGraphQL/productQuery.ts
@@ -28,9 +28,9 @@ query Product($identifier: ProductUniqueIdentifier) {
     items {
       itemId
       name
-      skuSpecifications {
-        fieldName
-        fieldValues
+      variations {
+        name
+        values
       }
     }
   }

--- a/node/index.ts
+++ b/node/index.ts
@@ -12,7 +12,7 @@ declare global {
 
   interface CustomContext {
     cookie: string
-    dataSources: StoreGraphQLDataSources
+    dataSources: SearchGraphQLDataSources
     originalPath: string
     vtex: CustomIOContext
   }
@@ -410,8 +410,8 @@ const MAX_SEGMENT_CACHE = 10000
 const segmentCache = new LRUCache<string, any>({ max: MAX_SEGMENT_CACHE })
 metrics.trackCache('segment', segmentCache)
 
-const storeGraphQLCache = new LRUCache<string, any>({ max: 5000 })
-metrics.trackCache('storeGraphQL', storeGraphQLCache)
+const searchGraphQLCache = new LRUCache<string, any>({ max: 5000 })
+metrics.trackCache('searchGraphQL', searchGraphQLCache)
 
 export default new Service<Clients, void, CustomContext>({
   clients: {
@@ -424,12 +424,12 @@ export default new Service<Clients, void, CustomContext>({
         retries: 2,
         timeout: THREE_SECONDS_MS,
       },
-      segment: {
-        memoryCache: segmentCache,
+      searchGraphQL: {
+        memoryCache: searchGraphQLCache,
         timeout: THREE_SECONDS_MS,
       },
-      storeGraphQL: {
-        memoryCache: storeGraphQLCache,
+      segment: {
+        memoryCache: segmentCache,
         timeout: THREE_SECONDS_MS,
       },
     },

--- a/node/resolvers/coupon.ts
+++ b/node/resolvers/coupon.ts
@@ -3,7 +3,7 @@ import { getNewOrderForm } from './orderForm'
 export const mutations = {
   insertCoupon: async (_: any, args: any, ctx: Context) => {
     const {
-      clients: { checkout, storeGraphQL },
+      clients: { checkout, searchGraphQL },
       vtex: { orderFormId },
     } = ctx
     const newOrderForm = await checkout.insertCoupon(orderFormId!, args.text)
@@ -11,7 +11,7 @@ export const mutations = {
     return getNewOrderForm({
       checkout,
       newOrderForm,
-      storeGraphQL,
+      searchGraphQL,
     })
   },
 }

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -1,5 +1,5 @@
 import { Checkout } from '../clients/checkout'
-import { StoreGraphQL } from '../clients/storeGraphQL'
+import { SearchGraphQL } from '../clients/searchGraphQL'
 import { adjustItems } from './items'
 import { fillMessages } from './messages'
 import { getShippingInfo } from './shipping'
@@ -7,11 +7,11 @@ import { getShippingInfo } from './shipping'
 export const getNewOrderForm = async ({
   checkout,
   newOrderForm,
-  storeGraphQL,
+  searchGraphQL,
 }: {
   checkout: Checkout
   newOrderForm: CheckoutOrderForm
-  storeGraphQL: StoreGraphQL
+  searchGraphQL: SearchGraphQL
 }) => {
   const { orderFormId, messages } = newOrderForm
 
@@ -22,7 +22,7 @@ export const getNewOrderForm = async ({
   }
 
   return {
-    items: await adjustItems(newOrderForm.items, storeGraphQL),
+    items: await adjustItems(newOrderForm.items, searchGraphQL),
     marketingData: newOrderForm.marketingData,
     messages: newMessages,
     shipping: getShippingInfo(newOrderForm),
@@ -34,7 +34,7 @@ export const getNewOrderForm = async ({
 export const queries = {
   orderForm: async (_: any, __: any, ctx: Context): Promise<OrderForm> => {
     const {
-      clients: { checkout, storeGraphQL },
+      clients: { checkout, searchGraphQL },
     } = ctx
 
     const newOrderForm = await checkout.orderForm()
@@ -42,7 +42,7 @@ export const queries = {
     return getNewOrderForm({
       checkout,
       newOrderForm,
-      storeGraphQL,
+      searchGraphQL,
     })
   },
 }

--- a/node/resolvers/shipping.ts
+++ b/node/resolvers/shipping.ts
@@ -72,7 +72,7 @@ export const mutations = {
     ctx: Context
   ) => {
     const {
-      clients: { checkout, shipping, storeGraphQL },
+      clients: { checkout, shipping, searchGraphQL },
       vtex: { orderFormId },
     } = ctx
 
@@ -89,7 +89,7 @@ export const mutations = {
     return getNewOrderForm({
       checkout,
       newOrderForm,
-      storeGraphQL,
+      searchGraphQL,
     })
   },
 }

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -19,11 +19,11 @@ declare global {
 
   interface ServiceContext extends KoaContext {
     vtex: IOContext
-    dataSources: StoreGraphQLDataSources
+    dataSources: SearchGraphQLDataSources
     originalPath: string
   }
 
-  interface StoreGraphQLDataSources {
+  interface SearchGraphQLDataSources {
     checkout: CheckoutDataSource
   }
 


### PR DESCRIPTION
#### What problem is this solving?

The `product` query from `store-graphql` [is being deprecated](https://vtex.slack.com/archives/C9P4RMW6Q/p1568813362048300) and moved to the new `search-graphql`. This PR adapts `checkout-graphql` to this change.

For now the translation of SKU variations won't work because `search-graphql` does not translate them. I [plan](https://app.clubhouse.io/vtex/story/20930/traduzir-variações-de-sku) on fixing this issue in a future PR.

#### How should this be manually tested?

[Workspace](https://search--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/20913/usar-o-search-graphql-no-checkout-graphql).
- [ ] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️| Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
