### PR TITLE
Add general messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `generalMessages` field to the `OrderFormMessages` type.
+
 ## [0.10.2] - 2019-09-18
 
 ### Changed

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -19,6 +19,7 @@ type Totalizer {
 
 type OrderFormMessages {
   couponMessages: [Message]
+  generalMessages: [Message]
 }
 
 type Message {

--- a/node/index.ts
+++ b/node/index.ts
@@ -387,6 +387,7 @@ declare global {
 
   interface OrderFormMessages {
     couponMessages: Message[]
+    generalMessages: Message[]
   }
 
   interface Message {

--- a/node/resolvers/messages.ts
+++ b/node/resolvers/messages.ts
@@ -1,17 +1,20 @@
-const COUPON_EXPIRED = 'couponExpired'
-const COUPON_NOT_FOUND = 'couponNotFound'
-
-const COUPON_CODES = [COUPON_EXPIRED, COUPON_NOT_FOUND]
+const COUPON_CODES = ['couponExpired', 'couponNotFound']
+const IGNORED_CODES = ['cannotBeDelivered']
 
 export const fillMessages = (messages: Message[]) => {
   const orderFormMessages = messages.reduce<OrderFormMessages>(
     (acc, message) => {
       if (COUPON_CODES.includes(message.code)) {
         acc.couponMessages.push(message)
+      } else if (!IGNORED_CODES.includes(message.code)) {
+        acc.generalMessages.push(message)
       }
       return acc
     },
-    { couponMessages: [] }
+    {
+      couponMessages: [],
+      generalMessages: [],
+    }
   )
 
   return orderFormMessages


### PR DESCRIPTION
#### What problem is this solving?

This PR adds to the `OrderForm` a new field `generalMessages` containing all messages sent by the API that will be displayed in the UI in a general context.

#### How should this be manually tested?

Perform manual GraphQL queries to the app.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/20914/implementar-toasts).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
