### PR TITLE
Translate SKU variations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `skuSpecifications` field now return translated name and values.
+
 ## [0.13.0] - 2019-09-24
 
 ### Added

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -21,8 +21,8 @@ type ItemAdditionalInfo {
 }
 
 type SKUSpecification {
-  fieldName: String
-  fieldValues: [String]
+  fieldName: String @translatable
+  fieldValues: [String] @translatable
 }
 
 input ItemInput {

--- a/node/resolvers/coupon.ts
+++ b/node/resolvers/coupon.ts
@@ -3,7 +3,7 @@ import { getNewOrderForm } from './orderForm'
 export const mutations = {
   insertCoupon: async (_: any, args: any, ctx: Context) => {
     const {
-      clients: { checkout, searchGraphQL },
+      clients: { checkout, searchGraphQL, segment },
       vtex: { orderFormId },
     } = ctx
     const newOrderForm = await checkout.insertCoupon(orderFormId!, args.text)
@@ -12,6 +12,7 @@ export const mutations = {
       checkout,
       newOrderForm,
       searchGraphQL,
+      segment,
     })
   },
 }

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -1,23 +1,50 @@
+import { Segment } from '@vtex/api'
 import { map } from 'bluebird'
+import crypto from 'crypto'
 
 import { SearchGraphQL } from '../clients/searchGraphQL'
 import { fixImageUrl } from '../utils/image'
 import { getNewOrderForm } from './orderForm'
 
-const getVariations = (skuId: string, skuList: any[]) => {
+const hashMD5 = (text: string) => {
+  const hash = crypto.createHash('md5')
+  return hash.update(text).digest('hex')
+}
+
+const toSpecificationIOMessage =
+  async (field: string, segment: Segment, content: string, id: string) => ({
+    content,
+    from: await segment.getSegmentByToken(null).then(x => x.cultureInfo),
+    id: `Specification-id.${id}::${field}`,
+  })
+
+const getVariations = (skuId: string, skuList: any[], segment: Segment) => {
   const matchedSku = skuList.find((sku: any) => sku.itemId === skuId)
   if (!matchedSku) {
     return []
   }
   return matchedSku.variations.map((variation: any) => ({
-    fieldName: variation.name,
-    fieldValues: variation.values,
+    fieldName: toSpecificationIOMessage(
+      'fieldName',
+      segment,
+      variation.name,
+      hashMD5(variation.name)
+    ),
+    fieldValues: variation.values.map(
+      (value: string) => toSpecificationIOMessage(
+        'fieldValue',
+        segment,
+        value,
+        hashMD5(value)
+      )
+    ),
   }))
 }
 
 export const adjustItems = (
   items: OrderFormItem[],
-  searchGraphQL: SearchGraphQL
+  searchGraphQL: SearchGraphQL,
+  segment: Segment
 ) =>
   map(items, async (item: OrderFormItem) => {
     const response = await searchGraphQL.product({
@@ -33,7 +60,7 @@ export const adjustItems = (
       ...item,
       imageUrl: fixImageUrl(item.imageUrl)!,
       name: product.productName,
-      skuSpecifications: getVariations(item.id, product.items),
+      skuSpecifications: getVariations(item.id, product.items, segment),
     }
   })
 
@@ -44,7 +71,7 @@ export const mutations = {
     ctx: Context
   ): Promise<OrderForm> => {
     const {
-      clients: { checkout, searchGraphQL },
+      clients: { checkout, searchGraphQL, segment },
       vtex: { orderFormId },
     } = ctx
 
@@ -72,6 +99,7 @@ export const mutations = {
       checkout,
       newOrderForm,
       searchGraphQL,
+      segment,
     })
   },
 }

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -1,3 +1,5 @@
+import { Segment } from '@vtex/api'
+
 import { Checkout } from '../clients/checkout'
 import { SearchGraphQL } from '../clients/searchGraphQL'
 import { adjustItems } from './items'
@@ -6,10 +8,12 @@ import { getShippingInfo } from './shipping/utils/shipping'
 
 export const getNewOrderForm = async ({
   checkout,
+  segment,
   newOrderForm,
   searchGraphQL,
 }: {
   checkout: Checkout
+  segment: Segment
   newOrderForm: CheckoutOrderForm
   searchGraphQL: SearchGraphQL
 }) => {
@@ -22,7 +26,7 @@ export const getNewOrderForm = async ({
   }
 
   return {
-    items: await adjustItems(newOrderForm.items, searchGraphQL),
+    items: await adjustItems(newOrderForm.items, searchGraphQL, segment),
     marketingData: newOrderForm.marketingData,
     messages: newMessages,
     shipping: getShippingInfo(newOrderForm),
@@ -34,7 +38,7 @@ export const getNewOrderForm = async ({
 export const queries = {
   orderForm: async (_: any, __: any, ctx: Context): Promise<OrderForm> => {
     const {
-      clients: { checkout, searchGraphQL },
+      clients: { checkout, searchGraphQL, segment },
     } = ctx
 
     const newOrderForm = await checkout.orderForm()
@@ -43,6 +47,7 @@ export const queries = {
       checkout,
       newOrderForm,
       searchGraphQL,
+      segment,
     })
   },
 }

--- a/node/resolvers/shipping/mutations.ts
+++ b/node/resolvers/shipping/mutations.ts
@@ -7,7 +7,7 @@ export const estimateShippingMutation = async (
   ctx: Context
 ) => {
   const {
-    clients: { checkout, shipping, searchGraphQL },
+    clients: { checkout, shipping, searchGraphQL, segment },
     vtex: { orderFormId },
   } = ctx
 
@@ -25,6 +25,7 @@ export const estimateShippingMutation = async (
     checkout,
     newOrderForm,
     searchGraphQL,
+    segment,
   })
 }
 
@@ -34,7 +35,7 @@ export const selectDeliveryOptionMutation = async (
   ctx: Context
 ) => {
   const {
-    clients: { checkout, shipping, searchGraphQL },
+    clients: { checkout, shipping, searchGraphQL, segment },
     vtex: { orderFormId },
   } = ctx
 
@@ -53,5 +54,6 @@ export const selectDeliveryOptionMutation = async (
     checkout,
     newOrderForm,
     searchGraphQL,
+    segment,
   })
 }


### PR DESCRIPTION
#### What problem is this solving?

SKU variations were not being translated after https://github.com/vtex/checkout-graphql/pull/18 because the new `search-graphql` does not return them translated anymore as opposed to `store-graphql`. This PR fixes this issue by simply copy-pasting the code from `store-graphql`.

#### How should this be manually tested?

Add [this item](https://skus--vtexgame1.myvtex.com/produto-variacao/p) then [go to cart in some language](https://skus--vtexgame1.myvtex.com/cart?cultureInfo=ja).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/20930/traduzir-variações-de-sku).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
