### PR TITLE
Use slug to identify item in search-graphql query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `search-graphql`'s `product` query receives the product slug instead of its id when the request comes from a GoCommerce account.
+
 ## [0.14.0] - 2019-10-10
 
 ### Changed

--- a/node/clients/searchGraphQL/index.ts
+++ b/node/clients/searchGraphQL/index.ts
@@ -12,7 +12,6 @@ export class SearchGraphQL extends AppGraphQLClient {
     query: string = productQuery
   ) => this.graphql.query<T, ProductArgs>({
     query,
-    useGet: true,
     variables,
   }, {
     metric: 'get-product',

--- a/node/clients/searchGraphQL/productQuery.ts
+++ b/node/clients/searchGraphQL/productQuery.ts
@@ -13,7 +13,8 @@ export interface ProductResponse {
 }
 
 export interface ProductArgs {
-  identifier: ProductUniqueIdentifier
+  identifier?: ProductUniqueIdentifier
+  slug?: string
 }
 
 interface ProductUniqueIdentifier {
@@ -22,8 +23,8 @@ interface ProductUniqueIdentifier {
 }
 
 export const query = `
-query Product($identifier: ProductUniqueIdentifier) {
-  product(identifier: $identifier) {
+query Product($identifier: ProductUniqueIdentifier, $slug: String) {
+  product(identifier: $identifier, slug: $slug) {
     productName
     items {
       itemId

--- a/node/package.json
+++ b/node/package.json
@@ -12,7 +12,7 @@
     "@types/lodash": "^4.14.138",
     "@types/node": "^10.12.17",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "^3.8.1",
+    "@vtex/api": "^3.55.2",
     "@vtex/test-tools": "^1.2.0",
     "@vtex/tsconfig": "^0.2.0",
     "tslint": "^5.12.0",

--- a/node/resolvers/coupon.ts
+++ b/node/resolvers/coupon.ts
@@ -4,13 +4,14 @@ export const mutations = {
   insertCoupon: async (_: any, args: any, ctx: Context) => {
     const {
       clients: { checkout, searchGraphQL },
-      vtex: { orderFormId },
+      vtex: { orderFormId, platform },
     } = ctx
     const newOrderForm = await checkout.insertCoupon(orderFormId!, args.text)
 
     return getNewOrderForm({
       checkout,
       newOrderForm,
+      platform,
       searchGraphQL,
     })
   },

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -7,10 +7,12 @@ import { getShippingInfo } from './shipping/utils/shipping'
 export const getNewOrderForm = async ({
   checkout,
   newOrderForm,
+  platform,
   searchGraphQL,
 }: {
   checkout: Checkout
   newOrderForm: CheckoutOrderForm
+  platform: string
   searchGraphQL: SearchGraphQL
 }) => {
   const { orderFormId, messages } = newOrderForm
@@ -22,7 +24,7 @@ export const getNewOrderForm = async ({
   }
 
   return {
-    items: await adjustItems(newOrderForm.items, searchGraphQL),
+    items: await adjustItems(platform, newOrderForm.items, searchGraphQL),
     marketingData: newOrderForm.marketingData,
     messages: newMessages,
     shipping: getShippingInfo(newOrderForm),
@@ -35,6 +37,7 @@ export const queries = {
   orderForm: async (_: any, __: any, ctx: Context): Promise<OrderForm> => {
     const {
       clients: { checkout, searchGraphQL },
+      vtex: { platform },
     } = ctx
 
     const newOrderForm = await checkout.orderForm()
@@ -42,6 +45,7 @@ export const queries = {
     return getNewOrderForm({
       checkout,
       newOrderForm,
+      platform,
       searchGraphQL,
     })
   },

--- a/node/resolvers/shipping/mutations.ts
+++ b/node/resolvers/shipping/mutations.ts
@@ -8,7 +8,7 @@ export const estimateShippingMutation = async (
 ) => {
   const {
     clients: { checkout, shipping, searchGraphQL },
-    vtex: { orderFormId },
+    vtex: { orderFormId, platform },
   } = ctx
 
   const orderForm = await checkout.orderForm()
@@ -24,6 +24,7 @@ export const estimateShippingMutation = async (
   return getNewOrderForm({
     checkout,
     newOrderForm,
+    platform,
     searchGraphQL,
   })
 }
@@ -35,7 +36,7 @@ export const selectDeliveryOptionMutation = async (
 ) => {
   const {
     clients: { checkout, shipping, searchGraphQL },
-    vtex: { orderFormId },
+    vtex: { orderFormId, platform },
   } = ctx
 
   const orderForm = await checkout.orderForm()
@@ -52,6 +53,7 @@ export const selectDeliveryOptionMutation = async (
   return getNewOrderForm({
     checkout,
     newOrderForm,
+    platform,
     searchGraphQL,
   })
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1324,13 +1324,14 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@^3.8.1":
-  version "3.31.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.31.0.tgz#a06b9daa6e998e25917aa15b1e508d059e794a34"
-  integrity sha512-aBJkfX6ZdlcjmyeWuyBw+EArczLJiQteCu5X7zb2tUP5uhPV40Do3E4SdbJwRNjkUkyTPE729GI0NBfZsnjBnw==
+"@vtex/api@^3.55.2":
+  version "3.55.2"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.55.2.tgz#086bfdc95d5da268a64f0a4df3e4879589e03e81"
+  integrity sha512-i0LaoSHJdGOwmlFDQ3X1RvY0mqQIFATH91VesLT20avgE6m/lQLvnSwVrX+zfI2SIsCpcMCHnUaJ+R8MIB/S/Q==
   dependencies:
     "@types/koa" "^2.0.48"
     "@types/koa-compose" "^3.2.3"
+    "@wry/equality" "^0.1.9"
     apollo-datasource "^0.3.1"
     apollo-server-core "^2.4.8"
     apollo-server-errors "^2.2.1"
@@ -1338,6 +1339,7 @@
     axios "^0.18.0"
     axios-retry "^3.1.2"
     bluebird "^3.5.4"
+    chalk "^2.4.2"
     co-body "^6.0.0"
     cookie "^0.3.1"
     dataloader "^1.4.0"
@@ -1412,7 +1414,7 @@
     "@types/node" ">=6"
     tslib "^1.9.3"
 
-"@wry/equality@^0.1.2":
+"@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
   integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==


### PR DESCRIPTION
#### What problem is this solving?

Our cart is breaking when used in GoCommerce accounts. The reason is that `search-graphql`'s `product` query in GoCommerce accounts must use the product's slug because of [this logic](https://github.com/vtex-apps/search-graphql/blob/master/node/resolvers/catalog/index.ts#L182). This PR changes `checkout-graphql` to use the product's slug to query `search-graphql` when the request comes from a GoCommerce account.

#### How should this be manually tested?

[Workspace in vtexgame1](https://slug--vtexgame1.myvtex.com)
[Workspace in madinejeans](https://slug--madinejeans.mygocommerce.com) (GoCommerce account)
Add any item, then go to `/cart`. Verify the cart loads correctly (the layout is broken, but the page should load without errors).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/23606/loja-da-gocommerce-não-carrega-o-carrinho).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
