### PR TITLE
Translate SKU variations

### DIFF
--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -6,7 +6,7 @@ on:
     - master
 
 jobs:
-  test-react:
+  test-node:
 
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `skuSpecifications` field now return translated name and values.
+
 ## [0.13.1] - 2019-10-01
 
 ### Fixed

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -21,8 +21,8 @@ type ItemAdditionalInfo {
 }
 
 type SKUSpecification {
-  fieldName: String
-  fieldValues: [String]
+  fieldName: String @translatableV2
+  fieldValues: [String] @translatableV2
 }
 
 input ItemInput {


### PR DESCRIPTION
_This PR has the same purpose as https://github.com/vtex/checkout-graphql/pull/24. I created another one because I GitHub did not allow me to reopen the previous one._

#### What problem is this solving?

SKU variations were not being translated after https://github.com/vtex/checkout-graphql/pull/18 because the new `search-graphql` does not return them translated anymore as opposed to `store-graphql`. This PR fixes this issue by simply adding the new `@translatableV2` directive to the SKU variation fields.

#### How should this be manually tested?

Add [this item](https://skus--vtexgame1.myvtex.com/produto-variacao/p) then [go to cart in some language](https://skus--vtexgame1.myvtex.com/cart?cultureInfo=ja). Verify the variation text is translated.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/20930/traduzir-variações-de-sku).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
