### PR TITLE
Add addToCart mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `addToCart` mutation.
+
 ## [0.14.2] - 2019-10-11
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -6,6 +6,7 @@ type Query {
 }
 
 type Mutation {
+  addToCart(items: [ItemInput]): OrderForm @withOrderFormId
   updateItems(orderItems: [ItemInput]): OrderForm @withOrderFormId
   insertCoupon(text: String): OrderForm @withOrderFormId
   estimateShipping(address: AddressInput): OrderForm @withOrderFormId

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -26,7 +26,9 @@ type SKUSpecification {
 }
 
 input ItemInput {
-  uniqueId: String
+  id: Int
   index: Int
   quantity: Float
+  seller: ID
+  uniqueId: String
 }

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -56,6 +56,26 @@ export const adjustItems = (
   })
 
 export const mutations = {
+  addToCart: async (
+    _: any,
+    { items }: { items: OrderFormItemInput[] },
+    ctx: Context
+  ): Promise<OrderForm> => {
+    const {
+      clients: { checkout, searchGraphQL },
+      vtex: { orderFormId, platform },
+    } = ctx
+
+    const newOrderForm = await checkout.addItem(orderFormId!, items)
+
+    return getNewOrderForm({
+      checkout,
+      newOrderForm,
+      platform,
+      searchGraphQL,
+    })
+  },
+
   updateItems: async (
     _: any,
     { orderItems }: { orderItems: OrderFormItemInput[] },


### PR DESCRIPTION
#### What problem is this solving?

This adds a mutation to the `checkout-graphql` that adds an array of items to the cart. This allows us to use our cart in the store page, add items via query strings and it may be used to implement the "undo" feature when removing an item.

#### How should this be manually tested?

With an empty cart, send the following mutation to `checkout-graphql` in `vtexgame1/addtocart`:
```gql
mutation addToCart($items: [ItemInput]) {
  addToCart(items: $items) {
    items {
      name
      quantity
    }
  }
}
```
with the following parameters:
```json
{
  "items": [
    {
      "id": 14,
      "quantity": 13,
      "seller": 1
    }
  ]
}
```
and verify in the response that the item was added successfully:
```json
"data": {
  "addToCart": {
    "items": [
      {
        "name": "Product Variation",
        "quantity": 13
      }
    ]
  }
}
```
#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/23743/mostrar-toast-no-carrinho-após-exclusão-de-produto-com-opção-para-desfazer-ação).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
