### PR TITLE
Fix image adjustment for GoCommerce and fallback to received URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Image URLs in non-VTEX accounts.
+
 ## [0.15.0] - 2019-10-14
 
 ### Added

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -49,7 +49,7 @@ export const adjustItems = (
 
     return {
       ...item,
-      imageUrl: fixImageUrl(item.imageUrl)!,
+      imageUrl: fixImageUrl(item.imageUrl, platform)!,
       name: product.productName,
       skuSpecifications: getVariations(item.id, product.items),
     }

--- a/node/utils/image/constants.ts
+++ b/node/utils/image/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_WIDTH = 96
+export const DEFAULT_HDF = 1

--- a/node/utils/image/gocommerce.ts
+++ b/node/utils/image/gocommerce.ts
@@ -1,0 +1,27 @@
+import { DEFAULT_HDF, DEFAULT_WIDTH } from './constants'
+
+const cleanImageUrl = (imageUrl: string | undefined) => {
+  if (!imageUrl) {
+    return undefined
+  }
+
+  return imageUrl.split('?')[0]
+}
+
+const changeImageUrlSize = (
+  imageUrl: string | undefined,
+  width = DEFAULT_WIDTH,
+  highDensityFactor = DEFAULT_HDF
+) => {
+  if (!imageUrl) {
+    return undefined
+  }
+
+  const widthCalc = width * highDensityFactor
+  return `${imageUrl}?width=${widthCalc}&height=auto&aspect=true`
+}
+
+export default {
+  changeImageUrlSize,
+  cleanImageUrl,
+}

--- a/node/utils/image/index.ts
+++ b/node/utils/image/index.ts
@@ -1,0 +1,37 @@
+import gocommerce from './gocommerce'
+import none from './none'
+import vtex from './vtex'
+
+interface Module {
+  cleanImageUrl: (imageUrl: string | undefined) => string | undefined
+  changeImageUrlSize: (imageUrl: string | undefined) => string | undefined
+}
+
+const replaceHttpToRelativeProtocol = (url: string | undefined) => {
+  if (!url) {
+    return undefined
+  }
+  return url.replace(/https:\/\/|http:\/\//, '//')
+}
+
+export const fixImageUrl = (imageUrl: string, platform: string) => {
+  const modules: Record<string, Module> = {
+    default: none,
+    gocommerce,
+    vtex,
+  }
+
+  const adjust = modules[platform] || modules.default
+
+  const fixedUrl = adjust.changeImageUrlSize(
+    adjust.cleanImageUrl(
+      replaceHttpToRelativeProtocol(imageUrl)
+    )
+  )
+
+  if (!fixedUrl) {
+    return imageUrl
+  }
+
+  return fixedUrl
+}

--- a/node/utils/image/none.ts
+++ b/node/utils/image/none.ts
@@ -1,0 +1,8 @@
+const cleanImageUrl = (imageUrl: string | undefined) => imageUrl
+
+const changeImageUrlSize = (imageUrl: string | undefined) => imageUrl
+
+export default {
+  changeImageUrlSize,
+  cleanImageUrl,
+}

--- a/node/utils/image/vtex.ts
+++ b/node/utils/image/vtex.ts
@@ -1,10 +1,13 @@
-const DEFAULT_WIDTH = 96
-const DEFAULT_HDF = 1
+import { DEFAULT_HDF, DEFAULT_WIDTH } from './constants'
 
 const baseUrlRegex = new RegExp(/.+ids\/(\d+)(?:-(\d+)-(\d+)|)\//)
 const sizeRegex = new RegExp(/-(\d+)-(\d+)/)
 
-const cleanImageUrl = (imageUrl: string) => {
+const cleanImageUrl = (imageUrl: string | undefined) => {
+  if (!imageUrl) {
+    return undefined
+  }
+
   let resizedImageUrl = imageUrl
   const result = baseUrlRegex.exec(imageUrl)
   if (result && result.length > 0) {
@@ -35,15 +38,7 @@ const changeImageUrlSize = (
   return `${resizedImageUrl}-${widthCalc}-auto`
 }
 
-const replaceHttpToRelativeProtocol = (url: string | undefined) => {
-  if (!url) {
-    return undefined
-  }
-  return url.replace(/https:\/\/|http:\/\//, '//')
-}
-
-export const fixImageUrl = (imageUrl: string) => {
-  return changeImageUrlSize(
-    replaceHttpToRelativeProtocol(cleanImageUrl(imageUrl))
-  )
+export default {
+  changeImageUrlSize,
+  cleanImageUrl,
 }


### PR DESCRIPTION
#### What problem is this solving?

Images were broken in GoCommerce stores because their URL do not follow the same pattern as VTEX stores, so the function that resizes the images was returning `undefined` for them.

This PR fixes this issue by implementing the image resizing function for GoCommerce and using the original URL as a fallback when the resizing logic fails.

#### How should this be manually tested?

Add [this item](https://img--gc-kck8880.mygocommerce.com/carrinho-2-porta-vermelho/p) (GC account), then to go `/cart`. Verify the image appears. Repeat with [this item](https://img--vtexgame1.myvtex.com/teste-so-delivery-copy-256--copy-257--copy-261--copy-262-/p) (VTEX account).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/24008/carrinho-no-gc-não-exibe-imagem-do-produto).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
