### PR TITLE
Add @2x image URLs to OrderForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- URLs to product images with 2x and 3x resolutions to OrderForm.
+
 ## [0.16.0] - 2019-10-31
 
 ### Added

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -6,7 +6,7 @@ type Item {
   availability: String
   detailUrl: String
   id: ID
-  imageUrl: String
+  imageUrls: ImageUrls
   listPrice: Float
   measurementUnit: String
   name: String
@@ -20,6 +20,12 @@ type Item {
   skuName: String
   skuSpecifications: [SKUSpecification]
   uniqueId: String
+}
+
+type ImageUrls {
+  at1x: String
+  at2x: String
+  at3x: String
 }
 
 type AssemblyOptionItem {

--- a/node/index.ts
+++ b/node/index.ts
@@ -345,8 +345,36 @@ declare global {
     options?: AssemblyOptionInput[]
   }
 
+  interface Item {
+    additionalInfo: {
+      brandName: string
+      brandId: string
+      offeringInfo: any | null
+      offeringType: any | null
+      offeringTypeId: any | null
+    }
+    availability: string
+    detailUrl: string
+    id: string
+    imageUrls?: {
+      at1x: string
+      at2x: string
+      at3x: string
+    }
+    listPrice: number
+    measurementUnit: string
+    name: string
+    price: number
+    productId: string
+    quantity: number
+    sellingPrice: number
+    skuName: string
+    skuSpecifications: SKUSpecification[]
+    uniqueId: string
+  }
+
   interface OrderForm {
-    items: OrderFormItem[]
+    items: Item[]
     shipping?: Shipping
     marketingData: OrderFormMarketingData | null
     totalizers: Array<{

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -50,7 +50,7 @@ export const adjustItems = (
 
     return {
       ...item,
-      imageUrl: fixImageUrl(item.imageUrl, platform)!,
+      imageUrls: fixImageUrl(item.imageUrl, platform),
       name: product.productName,
       skuSpecifications: getVariations(item.id, product.items),
     }

--- a/node/utils/image/gocommerce.ts
+++ b/node/utils/image/gocommerce.ts
@@ -10,8 +10,10 @@ const cleanImageUrl = (imageUrl: string | undefined) => {
 
 const changeImageUrlSize = (
   imageUrl: string | undefined,
-  width = DEFAULT_WIDTH,
-  highDensityFactor = DEFAULT_HDF
+  {
+    width = DEFAULT_WIDTH,
+    highDensityFactor = DEFAULT_HDF,
+  } = {}
 ) => {
   if (!imageUrl) {
     return undefined

--- a/node/utils/image/index.ts
+++ b/node/utils/image/index.ts
@@ -2,9 +2,15 @@ import gocommerce from './gocommerce'
 import none from './none'
 import vtex from './vtex'
 
+interface ImageOptions {
+  width?: number,
+  highDensityFactor?: number,
+}
+
 interface Module {
   cleanImageUrl: (imageUrl: string | undefined) => string | undefined
-  changeImageUrlSize: (imageUrl: string | undefined) => string | undefined
+  changeImageUrlSize: (imageUrl: string | undefined, options?: ImageOptions) =>
+    string | undefined
 }
 
 const replaceHttpToRelativeProtocol = (url: string | undefined) => {
@@ -23,15 +29,20 @@ export const fixImageUrl = (imageUrl: string, platform: string) => {
 
   const adjust = modules[platform] || modules.default
 
-  const fixedUrl = adjust.changeImageUrlSize(
-    adjust.cleanImageUrl(
-      replaceHttpToRelativeProtocol(imageUrl)
+  const cleanImageUrl = adjust.cleanImageUrl(
+    replaceHttpToRelativeProtocol(imageUrl)
+  )
+
+  const [at1x, at2x, at3x] = [1, 2, 3].map(
+    hdf => adjust.changeImageUrlSize(
+      cleanImageUrl,
+      { highDensityFactor: hdf }
     )
   )
 
-  if (!fixedUrl) {
-    return imageUrl
+  if (!at1x || !at2x || !at3x) {
+    return undefined
   }
 
-  return fixedUrl
+  return { at1x, at2x, at3x }
 }

--- a/node/utils/image/vtex.ts
+++ b/node/utils/image/vtex.ts
@@ -27,8 +27,10 @@ const cleanImageUrl = (imageUrl: string | undefined) => {
 
 const changeImageUrlSize = (
   imageUrl: string | undefined,
-  width = DEFAULT_WIDTH,
-  highDensityFactor = DEFAULT_HDF
+  {
+    highDensityFactor = DEFAULT_HDF,
+    width = DEFAULT_WIDTH,
+  } = {}
 ) => {
   if (!imageUrl) {
     return undefined


### PR DESCRIPTION
#### What problem is this solving?

This adds URLs to 2x and 3x product images to the OrderForm. The main goal is to display those images on devices with retina screens.

#### How should this be manually tested?

Send the following GraphQL query to `http://checkout-graphql.vtex.aws-us-east-1.vtex.io/checkoutio/retina/_v/graphql`:
```gql
query orderForm {
  orderForm {
    items {
      imageUrls {
        at1x
        at2x
        at3x
      }
    }
  }
}
```
with the `Cookie` header set to `checkout.vtex.com=__ofid=86f4219c07b74f7986603b11bd3eedb2` (or any order form id with a non-empty cart). The response should contain the URL for both image resolutions:
```json
  "data": {
    "orderForm": {
      "items": [
        {
          "imageUrls": {
            "at1x": "//vtexgame1.vteximg.com.br/arquivos/ids/155639-96-auto",
            "at2x": "//vtexgame1.vteximg.com.br/arquivos/ids/155639-192-auto",
            "at3x": "//vtexgame1.vteximg.com.br/arquivos/ids/155639-288-auto"
          }
        }
      ]
    }
  }
```

Alternatively, [go to store](https://retina--checkoutio.myvtex.com), add some item to cart then go to `/cart`. On retina (2x) displays, the image URL should end with `192-auto`. On regular screens, it should end with `96-auto`.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/21675/implementar-imagens-otimizadas-para-telas-retina).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
✔️ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
