### PR TITLE
Enforce AddressType type in GraphQL response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A GraphQL error would occur if the API returned an address type that was not in the AddressType enum.
+
 ## [0.18.0] - 2019-11-19
 
 ### Added

--- a/node/index.ts
+++ b/node/index.ts
@@ -414,17 +414,7 @@ declare global {
     text: string
     status: string
   }
-
-  enum AddressType {
-    residential,
-    commercial,
-    inStore,
-    giftRegistry,
-    pickup,
-    search,
-  }
 }
-
 // Segments are small and immutable.
 const MAX_SEGMENT_CACHE = 10000
 const segmentCache = new LRUCache<string, any>({ max: MAX_SEGMENT_CACHE })

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1,9 +1,10 @@
 import { mutations as couponMutations } from './coupon'
 import { mutations as itemMutations } from './items'
 import { queries as orderFormQueries } from './orderForm'
-import { mutations as shippingMutations } from './shipping/index'
+import { Address, mutations as shippingMutations } from './shipping/index'
 
 export const resolvers = {
+  Address,
   MarketingData: {
     coupon: (marketingData: OrderFormMarketingData) => {
       return marketingData.coupon || ''

--- a/node/resolvers/shipping/index.ts
+++ b/node/resolvers/shipping/index.ts
@@ -7,3 +7,31 @@ export const mutations = {
   estimateShipping: estimateShippingMutation,
   selectDeliveryOption: selectDeliveryOptionMutation,
 }
+
+enum AddressType {
+  residential = 'residential',
+  commercial = 'commercial',
+  inStore = 'inStore',
+  giftRegistry = 'giftRegistry',
+  pickup = 'pickup',
+  search = 'search',
+}
+
+const addressTypes = new Set<string>([
+  AddressType.commercial,
+  AddressType.giftRegistry,
+  AddressType.inStore,
+  AddressType.pickup,
+  AddressType.residential,
+  AddressType.search,
+])
+
+export const Address = {
+  addressType: ({ addressType }: CheckoutAddress) => {
+    if (addressTypes.has(addressType)) {
+      return addressType as AddressType
+    }
+
+    return null
+  },
+}


### PR DESCRIPTION
#### What problem is this solving?

The `checkout-graphql` app was logging a lot of errors in the `boticario` account because the API was returning an address type that wasn't expected by our GraphQL (the error message was `Expected a value of type "AddressType" but received: Residência`).

This PR fixes this issue by enforcing the `addressType` field of the GraphQL response to be have type `AddressType`. In case the API returns something different, our GraphQL returns `null`.

#### How should this be manually tested?

Interact with the cart in [this workspace](https://address--checkoutio.myvtex.com/cart/add?sku=31&sku=36&sku=33&sku=250&sku=17), or send GraphQL requests to `http://checkout-graphql.vtex.aws-us-east-1.vtex.io/{{account}}/{{workspace}}/_v/graphql`.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
