### PR TITLE
Add canEditData field to OrderForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `canEditData` field to the `OrderForm` type.
+
 ## [0.18.1] - 2019-11-26
 
 ### Fixed

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -1,5 +1,6 @@
 type OrderForm {
   items: [Item]
+  canEditData: Boolean
   shipping: Shipping
   marketingData: MarketingData
   totalizers: [Totalizer]

--- a/node/index.ts
+++ b/node/index.ts
@@ -379,6 +379,7 @@ declare global {
 
   interface OrderForm {
     items: Item[]
+    canEditData: boolean
     shipping?: Shipping
     marketingData: OrderFormMarketingData | null
     totalizers: Array<{

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -25,6 +25,7 @@ export const getNewOrderForm = async ({
 
   return {
     items: await adjustItems(platform, newOrderForm.items, searchGraphQL),
+    canEditData: newOrderForm.canEditData,
     marketingData: newOrderForm.marketingData,
     messages: newMessages,
     shipping: getShippingInfo(newOrderForm),


### PR DESCRIPTION
#### What problem is this solving?

The Checkout UI needs to decide whether an user should be able to edit postal code info, for instance, or not. This can be done using the info provided by the `OrderForm` field `canEditData`. This PR adds it.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Proceed to [graphiql](https://fixskeleton--checkoutio.myvtex.com/_v/private/vtex.checkout-graphql@0.18.1/graphiql/v1)

- Try the query below

`{
  orderForm {
    canEditData
  }
}`

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/27047/remover-a-op%C3%A7%C3%A3o-de-alterar-cep-no-carrinho-quando-usu%C3%A1rio-estiver-identificado)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
