### PR TITLE
Add number of unavailable items to shipping data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `numberOfUnavailableItems` to shipping data.
+
 ## [0.19.0] - 2019-12-10
 
 ### Added

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -3,6 +3,7 @@ type Shipping {
   deliveryOptions: [DeliveryOption]
   selectedAddress: Address
   availableAddresses: [Address]
+  numberOfUnavailableItems: Int
 }
 
 type DeliveryOption {

--- a/node/index.ts
+++ b/node/index.ts
@@ -395,6 +395,7 @@ declare global {
     availableAddresses: CheckoutAddress[]
     countries: string[]
     deliveryOptions: DeliveryOption[]
+    numberOfUnavailableItems: number
     selectedAddress: CheckoutAddress | null
   }
 

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -5,6 +5,7 @@ import { fixImageUrl } from '../utils/image'
 import { addOptionsForItems } from '../utils/attachmentsHelpers'
 import { getNewOrderForm } from './orderForm'
 
+const AVAILABLE = 'available'
 const GOCOMMERCE = 'gocommerce'
 
 const getProductInfo = async (
@@ -27,6 +28,16 @@ const getProductInfo = async (
   }
 
   return response.data!.product
+}
+
+export const getNumberOfUnavailableItems = (items: Item[]) => {
+  return items.reduce(
+    (numberOfUnavailableItems, item) =>
+      item.availability !== AVAILABLE
+        ? numberOfUnavailableItems + 1
+        : numberOfUnavailableItems,
+    0
+  )
 }
 
 const getVariations = (skuId: string, skuList: any[]) => {

--- a/node/resolvers/shipping/utils/shipping.ts
+++ b/node/resolvers/shipping/utils/shipping.ts
@@ -12,6 +12,8 @@ import {
   hasDeliveryOption,
 } from './delivery-options'
 
+import { getNumberOfUnavailableItems } from '../../items'
+
 export const getShippingData = (
   address: CheckoutAddress,
   logisticsInfo: LogisticsInfo[] | null
@@ -91,6 +93,8 @@ export const getShippingInfo = (orderForm: CheckoutOrderForm) => {
     logisticsInfo
   )
 
+  const numberOfUnavailableItems = getNumberOfUnavailableItems(orderForm.items)
+
   const updatedDeliveryOptions = getFormattedDeliveryOptions(
     filteredDeliveryOptions,
     logisticsInfo
@@ -101,5 +105,6 @@ export const getShippingInfo = (orderForm: CheckoutOrderForm) => {
     countries,
     deliveryOptions: updatedDeliveryOptions,
     selectedAddress,
+    numberOfUnavailableItems,
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

We need to show a warning if some products can't be delivered to a given address. To do that, a field called `numberOfUnavailableItems` was added to shipping data.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to the workspace [graphiql](https://deliveryfeedback--checkoutio.myvtex.com/_v/private/vtex.checkout-graphql@0.19.0/graphiql/v1)
- Try the query below
`{
  orderForm{
    shipping {
      numberOfUnavailableItems
    }
  }
}`

- Verify if it's giving a proper result

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/27145/implementar-tratamento-de-erros-para-delivery-options)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
