### PR TITLE
Make some fields non-nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,209 +6,146 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Several fields from the GraphQL schema are now non-nullable.
 
 ## [0.20.0] - 2019-12-18
-
 ### Fixed
-
 - Unavailable items causing empty `deliveryOptions`, since their logistics info do not have any slas.
 
 ## [0.19.1] - 2019-12-16
-
 ### Fixed
-
 - Inconsistency in shipping cost between Shipping Calculator and order form totalizer.
 
 ## [0.19.0] - 2019-12-10
-
 ### Added
-
 - `canEditData` field to the `OrderForm` type.
 
 ## [0.18.1] - 2019-11-26
-
 ### Fixed
-
 - A GraphQL error would occur if the API returned an address type that was not in the AddressType enum.
 
 ## [0.18.0] - 2019-11-19
-
 ### Added
-
 - `productCategories`, `productCategoryIds` and `productRefId` attributes to `Item` type.
 
 ## [0.17.0] - 2019-11-01
-
 ### Added
-
 - URLs to product images with 2x and 3x resolutions to OrderForm.
 
 ## [0.16.0] - 2019-10-31
-
 ### Added
-
 - Support for `AssemblyOptions` on `addToCart` mutation.
 
 ## [0.15.1] - 2019-10-15
-
 ### Fixed
-
 - Image URLs in non-VTEX accounts.
 
 ## [0.15.0] - 2019-10-14
-
 ### Added
-
 - `addToCart` mutation.
 
 ## [0.14.2] - 2019-10-11
-
 ### Fixed
-
 - Duplicated delivery options.
 
 ## [0.14.1] - 2019-10-10
-
 ### Changed
-
 - `search-graphql`'s `product` query receives the product slug instead of its id when the request comes from a GoCommerce account.
 
 ## [0.14.0] - 2019-10-10
-
 ### Changed
-
 - `skuSpecifications` field now return translated name and values.
 
 ## [0.13.1] - 2019-10-01
-
 ### Fixed
-
 - Tests related to shipping.
 
 ## [0.13.0] - 2019-09-24
-
 ### Added
-
 - `SelectDeliveryOption` mutation.
 
 ### Changed
-
 - `Shipping` resolver refactor and utility functions
 
 ## [0.12.1] - 2019-09-23
-
 ### Fixed
-
 - `availableAddresses` typo
 
 ## [0.12.0] - 2019-09-23
-
 ### Added
-
 - SLA filtering to return only Delivery SLAs
 
 ### Changed
-
 - Shipping to return array of selected addresses
 
 ## [0.11.0] - 2019-09-23
-
 ### Added
-
 - `generalMessages` field to the `OrderFormMessages` type.
 
 ## [0.10.2] - 2019-09-18
-
 ### Changed
-
 - `search-graphql` is used instead of `store-graphql` for the `product` query.
 
 ## [0.10.1] - 2019-09-13
-
 ### Changed
-
 - Image height is not fixed to 96 pixels anymore.
 
 ## [0.10.0] - 2019-09-12
-
 ### Added
-
 - `messages` field to `OrderForm`;
 - `marketingData` field resolver;
 - `OrderForm` messages being mapped to the proper Checkout OrderForm message fields.
 
 ## [0.9.0] - 2019-09-05
-
 ### Added
-
 - `availability` field to the `Item` GraphQL type.
 
 ## [0.8.2] - 2019-09-05
-
 ### Fixed
-
 - OrderForm's `marketingData` now can not be null.
 
 ## [0.8.1] - 2019-09-05
-
 ### Changed
-
 - insertCoupon returns the entire OrderForm.
 
 ## [0.8.0] - 2019-09-04
-
 ### Added
-
 - `estimateShipping` mutation to calculate delivery options;
 - `getNewOrderForm` to unify getting and returning a new orderForm;
 - Shipping information orderForm returned.
 
 ## [0.7.0] - 2019-09-02
-
 ### Changed
-
 - `updateItems` mutation now supports receiving an item's `uniqueId` instead of its `index`.
 
 ## [0.6.0] - 2019-08-29
-
 ### Changed
-
 - Renamed `cart` query to `orderForm`.
 - All mutations now return an OrderForm.
 
 ## [0.5.0] - 2019-08-26
-
 ### Added
-
 - InsertCoupon mutation.
 
 ## [0.4.0] - 2019-08-15
-
 ### Added
-
 - `totalizers` and `value` field in `cart` query.
 
 ## [0.3.0] - 2019-08-12
-
 ### Changed
-
 - Item variations now come from translated from `store-graphql`.
 - `variations` field was renamed to `skuSpecifications`.
 
 ## [0.2.0] - 2019-08-12
-
 ### Changed
-
 - `imageUrl` now returns a link with better image resolution.
 - Item name in `cart` query is now fetched translated from `store-graphql`.
 
 ### Added
-
 - Item `variations` field.
 
 ## [0.1.0] - 2019-08-02
-
 ### Added
-
 - Add items and storePreferencesData fields to the cart query.
 - Add updateItems mutation to update the items list.

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -8,30 +8,30 @@ type Item {
   assemblyOptions: AssemblyOptionItem
   availability: String
   detailUrl: String
-  id: ID
+  id: ID!
   imageUrls: ImageUrls
-  listPrice: Float
+  listPrice: Float!
   measurementUnit: String
   name: String
   parentAssemblyBinding: String
   options: [AssemblyOptionType]
-  price: Float
+  price: Float!
   productCategories: productCategoriesObject
   productCategoryIds: String
-  productId: String
+  productId: String!
   productRefId: String
-  quantity: Float
-  sellingPrice: Float
+  quantity: Float!
+  sellingPrice: Float!
   sellingPriceWithAssemblies: Float
   skuName: String
-  skuSpecifications: [SKUSpecification]
-  uniqueId: String
+  skuSpecifications: [SKUSpecification!]!
+  uniqueId: String!
 }
 
 type ImageUrls {
-  at1x: String
-  at2x: String
-  at3x: String
+  at1x: String!
+  at2x: String!
+  at3x: String!
 }
 
 type AssemblyOptionItem {
@@ -69,7 +69,7 @@ type ItemAdditionalInfo {
 
 type SKUSpecification {
   fieldName: String @translatableV2
-  fieldValues: [String] @translatableV2
+  fieldValues: [String]! @translatableV2
 }
 
 type AssemblyOptionType {

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -1,11 +1,11 @@
 type OrderForm {
-  items: [Item]
-  canEditData: Boolean
-  shipping: Shipping
-  marketingData: MarketingData
-  totalizers: [Totalizer]
-  value: Int
-  messages: OrderFormMessages
+  items: [Item!]!
+  canEditData: Boolean!
+  shipping: Shipping!
+  marketingData: MarketingData!
+  totalizers: [Totalizer]!
+  value: Int!
+  messages: OrderFormMessages!
 }
 
 type MarketingData {
@@ -13,14 +13,14 @@ type MarketingData {
 }
 
 type Totalizer {
-  id: String
+  id: String!
   name: String
-  value: Int
+  value: Int!
 }
 
 type OrderFormMessages {
-  couponMessages: [Message]
-  generalMessages: [Message]
+  couponMessages: [Message]!
+  generalMessages: [Message]!
 }
 
 type Message {

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -36,7 +36,7 @@ const getVariations = (skuId: string, skuList: any[]) => {
   }
   return matchedSku.variations.map((variation: any) => ({
     fieldName: variation.name,
-    fieldValues: variation.values,
+    fieldValues: variation.values || [],
   }))
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Each time we read a nullable variable from the GraphQL backend, we have to check if it isn't null before using it. This is pointless for variables we know will always be there. 
This PR marks some of the GraphQL schema fields as non-nullable, so we don't need to check null values in the front-end. This is part of the effort of improving the typing of our repos.

#### How should this be manually tested?

[This workspace](https://types--checkoutio.myvtex.com/cart/add?sku=31&sku=33&sku=250) should work fine.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/27230/melhorar-tipagem-das-apps-react).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
