### PR TITLE
Fix item's quantity update when there's more than one item with the s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Item's `quantity` update when there is more than one item with the same `uniqueId` (e.g gift items).
 
 ## [0.20.1] - 2019-12-18
 ### Changed

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -107,7 +107,9 @@ export const mutations = {
 
       const idToIndex = orderForm.items.reduce(
         (acc: Record<string, number>, item: OrderFormItem, index: number) => {
-          acc[item.uniqueId] = index
+          if (acc[item.uniqueId] === undefined) {
+            acc[item.uniqueId] = index
+          }
           return acc
         },
         {} as Record<string, number>


### PR DESCRIPTION
…ame uniqueId

#### What problem is this solving?

This PR fixes item's `quantity` update when there's more than one product with the same identifier. This scenario happens in promotions like "buy 2 take 3", since the API discriminates the gifted item, thus making it be another item in the item's list.

What was happening was that in the above scenario our graphql was sending to the API the wrong item to update. Since there was two products with the same identifiers (productId, uniqueId, etc) our graphql was sending the last item's `index` (which was the gift item) instead of the first one. 

This resulted on odd behaviors like changing the first item's quantity to 4, for example, and the API returning 8. 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Proceed to this [Workspace](https://phdro--paguemenos.myvtex.com/desodorante-dove-beauty-finish-aerossol-89g/p)
- Add the item to cart
- Open the minicart on the top right

**Try the cases below**

**Case 1**

- Change the first item's quantity to 3
- Check that a gifted items appears, being its quantity equal to 1, and the first ones being 2.

**Case 2**

- Change the first item's quantity to 5.
- Check that the gifted item's quantity is now 2, and the first one is 4. Since you are buying 6 products, you are paying for 4 and taking 2 for free.


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/29482/fix-altera%C3%A7%C3%A3o-incorreta-da-quantidade-de-produtos-em-cen%C3%A1rios-do-tipo-leve-x-pague-y)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️| Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
