### PR TITLE
Fix enconding of parameter of assemblies API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Simplify code path of `addToCart`.
+- Enconding of parameter of assemblies API.
 
 ## [0.25.1] - 2020-03-09
 

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -278,7 +278,7 @@ export class Checkout extends JanusClient {
         itemId: string | number,
         assemblyOptionsId: string
       ) =>
-        `${base}/orderForm/${orderFormId}/items/${itemId}/assemblyOptions/${assemblyOptionsId}`,
+        `${base}/orderForm/${orderFormId}/items/${itemId}/assemblyOptions/${encodeURI(assemblyOptionsId)}`,
       attachmentsData: (orderFormId: string, field: string) =>
         `${base}/orderForm/${orderFormId}/attachments/${field}`,
       cancelOrder: (orderFormId: string) =>


### PR DESCRIPTION
#### What problem is this solving?

Add an assembly with acent like ~ or ç.

#### How should this be manually tested?

1. Click in "Add Personalização"
2. Type anything inside the Texto field like "foo"
3. Click in "Add to Cart"
4. Go to the Checkout page and type: `vtexjs.checkout.orderForm.items[0].assemblies[0]` it should have something.

Fixed: https://breno--storecomponents.myvtex.com/wood-clock/p
Broken: https://storecomponents.myvtex.com/wood-clock/p

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [X] Updated/created tests (important for bug fixes).
- [X] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
