### PR TITLE
Add userProfileId field in OrderForm type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `userProfileId` field to `OrderForm` type.
+
 ## [0.25.2] - 2020-03-16
 
 ### Fixed

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -2,6 +2,7 @@ type OrderForm {
   id: ID!
   items: [Item!]!
   canEditData: Boolean!
+  userProfileId: String
   shipping: Shipping!
   marketingData: MarketingData!
   totalizers: [Totalizer]!


### PR DESCRIPTION
#### What problem is this solving?
Adds the `userProfileId` field to the `OrderForm`. This will be useful in the profile checkout step, to decide whether or not to show a checkbox that says if the user wants to save their profile information for future purchases.

[Related clubhouse story](https://app.clubhouse.io/vtex/story/32825/criar-componentes-de-profile-form-e-profile-preview)

#### How should this be manually tested?
[Workspace](https://chkio--checkoutio.myvtex.com/)

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->