### PR TITLE
Fix required installment fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error `Cannot return null for non-nullable field Installment.hasInterestRate`.
 
 ## [0.33.0] - 2020-04-24
 ### Added

--- a/graphql/types/Payment.graphql
+++ b/graphql/types/Payment.graphql
@@ -1,8 +1,8 @@
 type Installment {
   count: Int!
-  hasInterestRate: Boolean!
-  interestRate: Int!
-  value: Float!
+  hasInterestRate: Boolean
+  interestRate: Int
+  value: Float
   total: Float!
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Error: Cannot return null for non-nullable field `Installment.hasInterestRate`.

Required fields: 
`count`
`total`

The others fields can be `null`.
#### How should this be manually tested?

[Workspace](https://paymentio--checkoutio.myvtex.com/checkout/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
✔️ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

