### PR TITLE
Fix types for availableAccounts in profile query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Type for `availableAccounts` in `profile` query.
 
 ## [0.34.2] - 2020-05-19
 ### Added

--- a/graphql/types/Profile.graphql
+++ b/graphql/types/Profile.graphql
@@ -33,7 +33,7 @@ type UserProfile {
 type CheckoutProfile {
   userProfileId: String
   profileProvider: String
-  availableAccounts: [String!]!
-  availableAddresses: [Address]!
+  availableAccounts: [AvailableAccount!]!
+  availableAddresses: [Address!]!
   userProfile: UserProfile
 }

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "@types/lodash": "^4.14.138",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.28.3",
+    "@vtex/api": "6.30.1",
     "@vtex/test-tools": "^3.1.0",
     "@vtex/tsconfig": "^0.2.0",
     "typescript": "3.8.3",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1602,10 +1602,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@6.28.3":
-  version "6.28.3"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.28.3.tgz#866fdd9c42d9437672792c0135940143b73a7d58"
-  integrity sha512-KAjfjexcXKIpvOX+/z5iVDzWu6icTYH46FpEUSzDmJGmrfylUGEjSwtbzWbOeKwE8luUaoTgZOlaNVk+jEn4jg==
+"@vtex/api@6.30.1":
+  version "6.30.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.30.1.tgz#e71ebed6cff6bfdec928535133ffe6d0522797ae"
+  integrity sha512-HfE5Jxii3daU8s3B0FS/5fKeoObkqZkdGBSz8iwWvhYN+nCrvJWm7J0KT5MyGNphp0E3ShxoHQhF46RUG8yXVA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What problem is this solving?

This fixes the type for the `availableAccounts` in the `Profile` type (used only in the `profile` query for the identification step on the new Checkout). I don't know how this _ever_ worked before...

Note that this _technically_ is a breaking change, but it's safe to release since nobody is using the new Checkout yet, and without this it wouldn't work anyway 🤷‍♂️.

#### How should this be manually tested?

[Workspace](https://steps--checkoutio.myvtex.com/cart).

To test the changes, add some item in your cart in the above workspace and then use an email for an existing account that have some credit card registered (you can use `lucas@email.com`).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->