### PR TITLE
CHUI-9: Add proof-of-concept for validation of orderForm attachments

### DIFF
--- a/graphql/types/ClientProfile.graphql
+++ b/graphql/types/ClientProfile.graphql
@@ -14,4 +14,5 @@ type ClientData {
   profileCompleteOnLoading: Boolean
   profileErrorOnLoading: Boolean
   customerClass: String
+  isValid: Boolean!
 }

--- a/graphql/types/Payment.graphql
+++ b/graphql/types/Payment.graphql
@@ -63,6 +63,7 @@ type PaymentData {
   paymentSystems: [PaymentSystem!]!
   payments: [Payment!]!
   availableAccounts: [AvailableAccount!]!
+  isValid: Boolean!
 }
 
 type SavePaymentTokenPayload {

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -3,6 +3,7 @@ type Shipping {
   deliveryOptions: [DeliveryOption]
   selectedAddress: Address
   availableAddresses: [Address]
+  isValid: Boolean!
 }
 
 type DeliveryOption {

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -25,6 +25,26 @@ const replaceDomain = (host: string) => (cookie: string) =>
   cookie.replace(/domain=.+?(;|$)/, `domain=${host};`)
 
 export const root = {
+  PaymentData: {
+    isValid: (payment: PaymentData) => {
+      return !!(payment.payments.length > 0)
+    },
+  },
+  Shipping: {
+    isValid: (shipping: Shipping) => {
+      return !!(
+        shipping.selectedAddress &&
+        shipping.deliveryOptions?.some(
+          deliveryOption => deliveryOption?.isSelected
+        )
+      )
+    },
+  },
+  ClientData: {
+    isValid: (profile: ClientProfileData) => {
+      return !!(profile?.firstName && profile?.lastName && profile?.phone)
+    },
+  },
   OrderForm: {
     id: prop('orderFormId'),
     marketingData: propOr({}, 'marketingData'),

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -157,59 +157,8 @@ declare global {
       value: number
     }>
     shippingData: ShippingData
-    clientProfileData: any | null
-    paymentData: {
-      installmentOptions: Array<{
-        paymentSystem: string
-        bin: string | null
-        paymentName: string | null
-        paymentGroupName: string | null
-        value: number
-        installments: Array<{
-          count: number
-          hasInterestRate: false
-          interestRate: number
-          value: number
-          total: number
-          sellerMerchantInstallments: Array<{
-            count: number
-            hasInterestRate: false
-            interestRate: number
-            value: number
-            total: number
-          }>
-        }>
-      }>
-      paymentSystems: Array<{
-        id: string
-        name: string
-        groupName: string
-        validator: {
-          regex: string
-          mask: string
-          cardCodeRegex: string
-          cardCodeMask: string
-          weights: number[]
-          useCvv: boolean
-          useExpirationDate: boolean
-          useCardHolderName: boolean
-          useBillingAddress: boolean
-        }
-        stringId: string
-        template: string
-        requiresDocument: boolean
-        isCustom: boolean
-        description: string | null
-        requiresAuthentication: boolean
-        dueDate: string
-        availablePayments: any | null
-      }>
-      payments: any[]
-      giftCards: any[]
-      giftCardMessages: any[]
-      availableAccounts: any[]
-      availableTokens: any[]
-    }
+    clientProfileData: ClientProfileData | null
+    paymentData: PaymentData
     marketingData: OrderFormMarketingData | null
     sellers: Array<{
       id: string
@@ -258,6 +207,77 @@ declare global {
     availableAccounts: string[]
     availableAddresses: CheckoutAddress[]
     userProfile: any
+  }
+
+  interface ClientProfileData {
+    email: string
+    firstName: string
+    lastName: string
+    document: string
+    documentType: string
+    phone: string
+    corporateName: string
+    tradeName: string
+    corporateDocument: string
+    stateInscription: string
+    corporatePhone: string
+    isCorporate: boolean
+    profileCompleteOnLoading: boolean
+    profileErrorOnLoading: boolean
+    customerClass: string
+  }
+
+  interface PaymentData {
+    installmentOptions: Array<{
+      paymentSystem: string
+      bin: string | null
+      paymentName: string | null
+      paymentGroupName: string | null
+      value: number
+      installments: Array<{
+        count: number
+        hasInterestRate: false
+        interestRate: number
+        value: number
+        total: number
+        sellerMerchantInstallments: Array<{
+          count: number
+          hasInterestRate: false
+          interestRate: number
+          value: number
+          total: number
+        }>
+      }>
+    }>
+    paymentSystems: Array<{
+      id: string
+      name: string
+      groupName: string
+      validator: {
+        regex: string
+        mask: string
+        cardCodeRegex: string
+        cardCodeMask: string
+        weights: number[]
+        useCvv: boolean
+        useExpirationDate: boolean
+        useCardHolderName: boolean
+        useBillingAddress: boolean
+      }
+      stringId: string
+      template: string
+      requiresDocument: boolean
+      isCustom: boolean
+      description: string | null
+      requiresAuthentication: boolean
+      dueDate: string
+      availablePayments: any | null
+    }>
+    payments: any[]
+    giftCards: any[]
+    giftCardMessages: any[]
+    availableAccounts: any[]
+    availableTokens: any[]
   }
 
   interface ShippingData {


### PR DESCRIPTION
#### What problem is this solving?

POC for step validation in GraphQL. We will use this information on `checkout-container` to decide which step should be opened (via URL) and to block navigation for "future" steps (e.g. with invalid profile, the user shouldn't be able to go to shipping and payment, etc).

#### How should this be manually tested?

[Workspace](https://steps--checkoutio.myvtex.com/cart).

Test plan:

1. Add a product to your cart.
2. Go to checkout.
3. You should be redirected to the identification page, if you're not logged in yet.
4. After typing your email, you will be redirected to the profile step.
5. Try to edit the shipping and/or payment before filling the profile, you shouldn't be able to.
6. Also try to manually edit the url to be in a step that you aren't supposed to be.
7. Proceed normally with the checkout flow and you should be able to reach the review step in a natural manner.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->