### PR TITLE
CHK-85: Fix error when country config app isn't installed in store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error when validating shipping data when country data config app isn't installed in the account.
 
 ## [0.36.0] - 2020-07-07
 ### Added

--- a/node/clients/countryDataSettings.ts
+++ b/node/clients/countryDataSettings.ts
@@ -13,7 +13,9 @@ export class CountryDataSettings extends AppClient {
     })
   }
 
-  public getCountrySettings(country: string): Promise<CountryDataSchema> {
+  public getCountrySettings(
+    country: string
+  ): Promise<CountryDataSchema | null> {
     return this.http.get(`/country-settings/${country}`)
   }
 

--- a/node/utils/validation.ts
+++ b/node/utils/validation.ts
@@ -31,6 +31,10 @@ export const isShippingValid = async (
     address.country
   )
 
+  if (!countrySettings) {
+    return false
+  }
+
   const fields = countrySettings.addressFields
 
   for (const [field, fieldSchema] of Object.entries(fields) as Array<


### PR DESCRIPTION
#### What problem is this solving?

Fixes an issue observed during the deploy of #78, where the functions that validated the attachments throwed an error when the configuration for the specific country in the store didn't exist. [Here is the Splunk query](https://splunk72.vtex.com/en-US/app/vtex_io_apps/search?q=search%20index%3Dio_vtex_logs%20production%3Dtrue%20level%3Derror%20data.message!%3DPersistedQueryNotFound%20app%3Dvtex.checkout-graphql%40*%20cluster!%3Dtest*%20cluster%3D*%20%20%22data.message%22%3D%22Cannot%20convert%20undefined%20or%20null%20to%20object%22&earliest=1594105739&latest=1594135439&sid=1594143077.46834_D730961E-090B-4E7E-A081-1F7623D93A11&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=).

#### How should this be manually tested?

[Workspace](https://nocountries--checkoutio.myvtex.com/cart/add?sku=289).

In the above workspace I uninstalled the country data config apps (`vtex.country-data-bra` and friends) so we can properly test this behavior.

To test you can simply input a zipcode in the cart page, and it should fill the address correctly and show the shipping options without error.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->