### PR TITLE
Attempt to fix communication errors with search-graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error when communicating with `vtex.search-graphql` breaking all queries related to the order form.
 
 ## [0.36.1] - 2020-07-08
 ### Fixed

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -69,10 +69,15 @@ export const root = {
     items: (orderForm: CheckoutOrderForm, _: unknown, ctx: Context) => {
       const {
         clients: { searchGraphQL },
-        vtex: { platform },
+        vtex: { platform, logger },
       } = ctx
 
-      return adjustItems(platform, orderForm.items, searchGraphQL)
+      return adjustItems({
+        platform,
+        items: orderForm.items,
+        searchGraphQL,
+        logger,
+      })
     },
     clientProfileData: async (
       orderForm: CheckoutOrderForm,


### PR DESCRIPTION
#### What problem is this solving?

This PR is an attempt to see if we can reduce the amount of errors in our responses due to the communication with `vtex.search-graphql`. For those that were unaware of this, we actually receive a lot of errors due to this API call, because the legacy search (the one developed in the Portal platform) responds a 404 status when you request a product that doesn't have stock, even though we are just requesting it to see the sku variations, and not to display in a product page. I guess we can get over with it by not having the sku variations displayed on our minicart if we can't get this information from the Search API.. and it would make our lives a lot easier when publishing/deploying new versions of this app.

#### How should this be manually tested?

Not much to test because I don't know _how_ to add a product to cart if it doesn't have stock..

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->