### PR TITLE
Release v0.36.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.4] - 2020-07-09
+
 ## [0.36.3] - 2020-07-08
 ### Fixed
 - Call to session API when `vtex_session` cookie isn't present.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "checkout-graphql",
   "vendor": "vtex",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "title": "Checkout GraphQL",
   "description": "Checkout GraphQL API",
   "builders": {
@@ -14,9 +14,7 @@
   },
   "credentialType": "absolute",
   "mustUpdateAt": "2019-11-05",
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [
     {
       "name": "outbound-access",


### PR DESCRIPTION
The latest deploy of this app caused triggered some alarms. I don't know exactly what caused the issue, but I'm releasing a new version so we can be sure that we are on a "clean" version.