### PR TITLE
Adds policy to allow other apps to call this one

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "@types/lodash": "^4.14.138",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.35.0",
+    "@vtex/api": "6.35.2",
     "@vtex/test-tools": "^3.1.0",
     "@vtex/tsconfig": "^0.2.0",
     "typescript": "3.8.3",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1602,10 +1602,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@6.35.0":
-  version "6.35.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.35.0.tgz#1970a8974f8bf9fbc70fb4e6758b78d46c8b1f87"
-  integrity sha512-RWH9wqpHHV0FtGlK4AxrsFcjVxhl3ZVTQRKboEgOI+7Ts9scLkBoEyYnwtQzvjfAkJgxUNCmvqsKPN2HxAnWlQ==
+"@vtex/api@6.35.2":
+  version "6.35.2"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.35.2.tgz#7b6f20295c13863bc9c9e3af82c5b12a861c27f8"
+  integrity sha512-FOOzGa2krqUHc0IHsgazlZzsml2EL1DzqDyiVmvnuWFN0Xf+FT06Ppoil77fIGPhaEfLNsmX3uUYXXsQA9W4gQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/policies.json
+++ b/policies.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "resolve-graphql",
+    "description": "Allows access to resolve a graphql request",
+    "statements": [
+      {
+        "actions": ["post", "get"],
+        "effect": "allow",
+        "resources": [
+          "vrn:vtex.checkout-graphql:{{region}}:{{account}}:{{workspace}}:/_v/graphql"
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
#### What problem is this solving?
This PR adds a policy to this app so other apps can call this one.

For other apps to call this one, just add 
```
"policies": [,
    {
      "name": "vtex.checkout-graphql:resolve-graphql"
    }
  ]
```

in the app' s manifest.json

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
