### PR TITLE
Fix error when marketing data in addToCart is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error when marketing data in `addToCart` mutation was `null`.
 
 ## [0.36.5] - 2020-07-15
 ### Fixed

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -87,8 +87,10 @@ export const mutations = {
       clients,
       vtex: { orderFormId, logger },
     } = ctx
+
     const { checkout } = clients
-    const shouldUpdateMarketingData = Object.keys(marketingData).length > 0
+    const shouldUpdateMarketingData =
+      Object.keys(marketingData ?? {}).length > 0
 
     const { items: previousItems } = await checkout.orderForm()
     const cleanItems = items.map(({ options, ...rest }) => rest)


### PR DESCRIPTION
#### What problem is this solving?

Fixes the error `Cannot convert null or undefined to object` when calling the `addToCart` mutation with `marketingData` as `null`.

#### How should this be manually tested?

[Workspace](https://lucas--storecomponents.myvtex.com/_v/private/vtex.checkout-graphql@0.36.5/graphiql/v1).

Use the following mutation

```graphql
mutation {
  addToCart(items: [{ id: 2000583, quantity: 1, seller: "1" }], marketingData: null) {
    id
  }
}
```

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->