### PR TITLE
Add orderFormId argument to queries and mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Optional argument `orderFormId` to all queries and mutation that alters
+  information in the cart.
 
 ## [0.41.1] - 2020-09-29
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,6 +1,6 @@
 type Query {
   getCardSessionId: String
-  orderForm: OrderForm
+  orderForm(orderFormId: ID): OrderForm!
     @cacheControl(scope: PRIVATE)
     @withOrderFormId
     @withSegment
@@ -8,46 +8,66 @@ type Query {
 }
 
 type Mutation {
-  addToCart(items: [ItemInput], marketingData: MarketingDataInput): OrderForm
+  addToCart(
+    orderFormId: ID
+    items: [ItemInput]
+    marketingData: MarketingDataInput
+  ): OrderForm! @withOrderFormId @withSegment
+
+  updateItems(
+    orderFormId: ID
+    orderItems: [ItemInput]
+    splitItem: Boolean = true
+  ): OrderForm! @withOrderFormId
+
+  addItemOffering(orderFormId: ID, offeringInput: OfferingInput): OrderForm!
     @withOrderFormId
-    @withSegment
+  removeItemOffering(orderFormId: ID, offeringInput: OfferingInput): OrderForm!
+    @withOrderFormId
 
-  updateItems(orderItems: [ItemInput], splitItem: Boolean = true): OrderForm @withOrderFormId
+  addBundleItemAttachment(
+    orderFormId: ID
+    bundleItemAttachmentInput: BundleItemAttachmentInput
+  ): OrderForm! @withOrderFormId
+  removeBundleItemAttachment(
+    orderFormId: ID
+    bundleItemAttachmentInput: BundleItemAttachmentInput
+  ): OrderForm! @withOrderFormId
 
-  addItemOffering(offeringInput: OfferingInput): OrderForm @withOrderFormId
-  removeItemOffering(offeringInput: OfferingInput): OrderForm @withOrderFormId
+  insertCoupon(orderFormId: ID, text: String): OrderForm! @withOrderFormId
 
-  addBundleItemAttachment(bundleItemAttachmentInput: BundleItemAttachmentInput): OrderForm @withOrderFormId
-  removeBundleItemAttachment(bundleItemAttachmentInput: BundleItemAttachmentInput): OrderForm @withOrderFormId
+  estimateShipping(orderFormId: ID, address: AddressInput): OrderForm!
+    @withOrderFormId
 
-  insertCoupon(text: String): OrderForm @withOrderFormId
-
-  estimateShipping(address: AddressInput): OrderForm @withOrderFormId
-
-  selectDeliveryOption(deliveryOptionId: String): OrderForm @withOrderFormId
+  selectDeliveryOption(orderFormId: ID, deliveryOptionId: String): OrderForm!
+    @withOrderFormId
 
   """
   Changes the currently selected address in the shipping data
   of the OrderForm
   """
-  updateSelectedAddress(input: AddressInput!): OrderForm @withOrderFormId
-
-  savePaymentToken(paymentTokens: [PaymentToken]): SavePaymentTokenPayload
+  updateSelectedAddress(orderFormId: ID, input: AddressInput!): OrderForm!
     @withOrderFormId
 
-  updateOrderFormProfile(input: UserProfileInput!): OrderForm!
-    @withOrderFormId
-    @cacheControl(scope: PRIVATE)
+  savePaymentToken(
+    orderFormId: ID
+    paymentTokens: [PaymentToken]
+  ): SavePaymentTokenPayload @withOrderFormId
 
-  updateClientPreferencesData(input: ClientPreferencesDataInput!): OrderForm!
-    @withOrderFormId
-    @cacheControl(scope: PRIVATE)
-
-  updateOrderFormPayment(input: PaymentDataInput!): OrderForm!
+  updateOrderFormProfile(orderFormId: ID, input: UserProfileInput!): OrderForm!
     @withOrderFormId
     @cacheControl(scope: PRIVATE)
 
-  setManualPrice(input: ManualPriceInput!): OrderForm!
+  updateClientPreferencesData(
+    orderFormId: ID
+    input: ClientPreferencesDataInput!
+  ): OrderForm! @withOrderFormId @cacheControl(scope: PRIVATE)
+
+  updateOrderFormPayment(orderFormId: ID, input: PaymentDataInput!): OrderForm!
+    @withOrderFormId
+    @cacheControl(scope: PRIVATE)
+
+  setManualPrice(orderFormId: ID, input: ManualPriceInput!): OrderForm!
     @withOrderFormId
     @cacheControl(scope: PRIVATE)
 }

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -226,17 +226,17 @@ export class Checkout extends JanusClient {
       metric: 'checkout-updateOrderFormCheckin',
     })
 
-  public orderForm = () => {
+  public orderForm = (orderFormId: string) => {
     return this.post<CheckoutOrderForm>(
-      this.routes.orderForm,
+      this.routes.orderForm(orderFormId),
       {},
       { metric: 'checkout-orderForm' }
     )
   }
 
-  public orderFormRaw = () => {
+  public orderFormRaw = (orderFormId?: string) => {
     return this.postRaw<CheckoutOrderForm>(
-      this.routes.orderForm,
+      this.routes.orderForm(orderFormId),
       {},
       { metric: 'checkout-orderForm' }
     )
@@ -369,7 +369,8 @@ export class Checkout extends JanusClient {
         `${base}/orderForm/${orderFormId}/messages/clear`,
       insertCoupon: (orderFormId: string) =>
         `${base}/orderForm/${orderFormId}/coupons`,
-      orderForm: `${base}/orderForm`,
+      orderForm: (orderFormId?: string) =>
+        `${base}/orderForm/${orderFormId ?? ''}`,
       orderFormCustomData: (
         orderFormId: string,
         appId: string,

--- a/node/resolvers/coupon.ts
+++ b/node/resolvers/coupon.ts
@@ -1,9 +1,13 @@
+import { OrderFormIdArgs } from '../utils/args'
+
 export const mutations = {
-  insertCoupon: async (_: any, args: any, ctx: Context) => {
-    const {
-      clients,
-      vtex: { orderFormId },
-    } = ctx
+  insertCoupon: async (
+    _: unknown,
+    args: { text: string } & OrderFormIdArgs,
+    ctx: Context
+  ) => {
+    const { clients, vtex } = ctx
+    const { orderFormId = vtex.orderFormId } = args
 
     const newOrderForm = await clients.checkout.insertCoupon(
       orderFormId!,

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -9,6 +9,7 @@ import {
   isPaymentValid,
 } from '../utils/validation'
 import { VTEX_SESSION } from '../constants'
+import { OrderFormIdArgs } from '../utils/args'
 
 interface StoreSettings {
   enableOrderFormOptimization: boolean
@@ -161,15 +162,15 @@ export async function forwardCheckoutCookies(
 export const queries = {
   orderForm: async (
     _: unknown,
-    __: unknown,
+    args: OrderFormIdArgs,
     ctx: Context
   ): Promise<CheckoutOrderForm> => {
-    const { clients } = ctx
+    const { clients, vtex } = ctx
+    const { orderFormId = vtex.orderFormId } = args
 
-    const {
-      data: newOrderForm,
-      headers,
-    } = await clients.checkout.orderFormRaw()
+    const { data: newOrderForm, headers } = await clients.checkout.orderFormRaw(
+      orderFormId
+    )
 
     /**
      * In case the enableOrderFormOptimization setting is enabled in the store,
@@ -203,13 +204,14 @@ interface MutationUpdateOrderFormPaymentArgs {
 export const mutations = {
   updateOrderFormProfile: async (
     _: unknown,
-    { input }: MutationUpdateOrderFormProfileArgs,
+    args: MutationUpdateOrderFormProfileArgs & OrderFormIdArgs,
     ctx: Context
   ): Promise<CheckoutOrderForm> => {
     const {
       clients: { checkout },
-      vtex: { orderFormId },
+      vtex,
     } = ctx
+    const { input, orderFormId = vtex.orderFormId } = args
 
     const orderFormWithProfile = await checkout.updateOrderFormProfile(
       orderFormId!,
@@ -220,13 +222,14 @@ export const mutations = {
   },
   updateClientPreferencesData: async (
     _: unknown,
-    { input }: MutationUpdateClientPreferencesDataArgs,
+    args: MutationUpdateClientPreferencesDataArgs & OrderFormIdArgs,
     ctx: Context
   ) => {
     const {
       clients: { checkout },
-      vtex: { orderFormId },
+      vtex,
     } = ctx
+    const { orderFormId = vtex.orderFormId, input } = args
 
     const updatedOrderForm = await checkout.updateOrderFormClientPreferencesData(
       orderFormId!,
@@ -240,17 +243,20 @@ export const mutations = {
   },
   updateOrderFormPayment: async (
     _: unknown,
-    { input }: MutationUpdateOrderFormPaymentArgs,
+    args: MutationUpdateOrderFormPaymentArgs & OrderFormIdArgs,
     ctx: Context
   ): Promise<CheckoutOrderForm> => {
     const {
       clients: { checkout },
-      vtex: { orderFormId },
+      vtex,
     } = ctx
+    const { orderFormId = vtex.orderFormId, input } = args
+
     const orderFormWithPayments = await checkout.updateOrderFormPayment(
       orderFormId!,
       input
     )
+
     return orderFormWithPayments
   },
 }

--- a/node/resolvers/shipping.ts
+++ b/node/resolvers/shipping.ts
@@ -4,6 +4,7 @@ import {
   selectAddress,
 } from '../utils/shipping'
 import { AddressType } from '../constants'
+import { OrderFormIdArgs } from '../utils/args'
 
 const addressTypes = new Set<string>([
   AddressType.COMMERCIAL,
@@ -29,83 +30,71 @@ export const root = {
 export const mutations = {
   estimateShipping: async (
     _: unknown,
-    { address }: { address: CheckoutAddress },
+    args: { address: CheckoutAddress } & OrderFormIdArgs,
     ctx: Context
   ) => {
-    const {
-      clients,
-      vtex: { orderFormId },
-    } = ctx
+    const { clients, vtex } = ctx
     const { checkout } = clients
+    const { orderFormId = vtex.orderFormId, address } = args
 
-    const orderForm = await checkout.orderForm()
+    const orderForm = await checkout.orderForm(orderFormId!)
     const logisticsInfo =
       orderForm.shippingData && orderForm.shippingData.logisticsInfo
     const shippingData = getShippingData(address, logisticsInfo)
 
-    const newOrderForm = await checkout.updateOrderFormShipping(
-      orderFormId!,
-      {
-        ...shippingData,
-        clearAddressIfPostalCodeNotFound: false,
-      },
-    )
+    const newOrderForm = await checkout.updateOrderFormShipping(orderFormId!, {
+      ...shippingData,
+      clearAddressIfPostalCodeNotFound: false,
+    })
 
     return newOrderForm
   },
 
   selectDeliveryOption: async (
     _: unknown,
-    { deliveryOptionId }: { deliveryOptionId: string },
+    args: { deliveryOptionId: string } & OrderFormIdArgs,
     ctx: Context
   ) => {
-    const {
-      clients,
-      vtex: { orderFormId },
-    } = ctx
+    const { clients, vtex } = ctx
     const { checkout } = clients
+    const { orderFormId = vtex.orderFormId, deliveryOptionId } = args
 
-    const orderForm = await checkout.orderForm()
+    const orderForm = await checkout.orderForm(orderFormId!)
     const newShippingData = selectDeliveryOption({
       deliveryOptionId,
       shippingData: orderForm.shippingData,
     })
 
-    const newOrderForm = await checkout.updateOrderFormShipping(
-      orderFormId!,
-      {
-        ...newShippingData,
-        clearAddressIfPostalCodeNotFound: false,
-      },
-    )
+    const newOrderForm = await checkout.updateOrderFormShipping(orderFormId!, {
+      ...newShippingData,
+      clearAddressIfPostalCodeNotFound: false,
+    })
 
     return newOrderForm
   },
 
   updateSelectedAddress: async (
     _: unknown,
-    { input }: { input: CheckoutAddress },
+    args: { input: CheckoutAddress } & OrderFormIdArgs,
     ctx: Context
   ) => {
     const {
       clients: { checkout },
-      vtex: { orderFormId },
+      vtex,
     } = ctx
+    const { orderFormId = vtex.orderFormId, input } = args
 
-    const orderForm = await checkout.orderForm()
+    const orderForm = await checkout.orderForm(orderFormId!)
 
     const newShippingData = selectAddress({
       address: input,
       shippingData: orderForm.shippingData,
     })
 
-    const newOrderForm = await checkout.updateOrderFormShipping(
-      orderFormId!,
-      {
-        ...newShippingData,
-        clearAddressIfPostalCodeNotFound: false,
-      },
-    )
+    const newOrderForm = await checkout.updateOrderFormShipping(orderFormId!, {
+      ...newShippingData,
+      clearAddressIfPostalCodeNotFound: false,
+    })
 
     return newOrderForm
   },

--- a/node/utils/args.ts
+++ b/node/utils/args.ts
@@ -1,0 +1,3 @@
+export interface OrderFormIdArgs {
+  orderFormId?: string
+}


### PR DESCRIPTION
#### What problem is this solving?

Adds the possibility to use the explicit param `orderFormId` in the queries and mutations of this GraphQL server. This is useful for environments where the use of cookies is pretty limited and the usage of GraphQL arguments is preferred (due to caching policies), e.g. in faststore.

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/_v/private/vtex.checkout-graphql@0.36.6/graphiql/v1?query=query%20%7B%0A%20%20orderForm(orderFormId%3A%20%22a5336504f77b407081fb5b8a9fd26a76%22)%20%7B%0A%20%20%20%20id%0A%20%20%20%20items%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20skuName%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&variables=%7B%0A%20%20%22orderFormId1%22%3A%20%22c6735f99232d43229fddca00257632ce%22%2C%0A%20%20%22orderFormId2%22%3A%20%22a5336504f77b407081fb5b8a9fd26a76%22%0A%7D).

You can use the query above and test changing the parameter `orderFormId` between the two values in the query variables. The id of the returned orderForm should change accordingly.

Furthermore, if you remove the `orderFormId` of the query it should return the orderForm of the last orderFormId you used.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->