### PR TITLE
Feature/split item on update items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `splitItem` parameter on `updateItems` mutatioin. 
 
 ## [0.38.0] - 2020-09-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- `splitItem` parameter on `updateItems` mutatioin. 
+- `splitItem` parameter on `updateItems` mutation. 
 
 ## [0.38.0] - 2020-09-11
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -12,7 +12,7 @@ type Mutation {
     @withOrderFormId
     @withSegment
 
-  updateItems(orderItems: [ItemInput]): OrderForm @withOrderFormId
+  updateItems(orderItems: [ItemInput], splitItem: Boolean = true): OrderForm @withOrderFormId
 
   addItemOffering(offeringInput: OfferingInput): OrderForm @withOrderFormId
   removeItemOffering(offeringInput: OfferingInput): OrderForm @withOrderFormId

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -69,10 +69,10 @@ export class Checkout extends JanusClient {
       { metric: 'checkout-setOrderFormCustomData' }
     )
 
-  public updateItems = (orderFormId: string, orderItems: any) =>
+  public updateItems = (orderFormId: string, orderItems: any, splitItem: boolean) =>
     this.post<CheckoutOrderForm>(
       this.routes.updateItems(orderFormId),
-      { orderItems },
+      { orderItems, noSplitItem: !splitItem},
       { metric: 'checkout-updateItems' }
     )
 

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -140,7 +140,7 @@ export const mutations = {
 
   updateItems: async (
     _: unknown,
-    { orderItems }: { orderItems: OrderFormItemInput[] },
+    { orderItems, splitItem }: { orderItems: OrderFormItemInput[], splitItem: boolean },
     ctx: Context
   ): Promise<CheckoutOrderForm> => {
     const {
@@ -168,10 +168,14 @@ export const mutations = {
         }
       })
     }
+    console.log(splitItem)
+    const senSplitItem = false;
+    console.log(senSplitItem)
 
     const newOrderForm = await clients.checkout.updateItems(
       orderFormId!,
-      orderItems
+      orderItems,
+      senSplitItem
     )
 
     return newOrderForm

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -168,14 +168,11 @@ export const mutations = {
         }
       })
     }
-    console.log(splitItem)
-    const senSplitItem = false;
-    console.log(senSplitItem)
 
     const newOrderForm = await clients.checkout.updateItems(
       orderFormId!,
       orderItems,
-      senSplitItem
+      splitItem
     )
 
     return newOrderForm


### PR DESCRIPTION
#### What problem is this solving?

The inability to choose whether or not a updated product will split when using mutation updateItems

#### How should this be manually tested?

Using the query:
```graphql
mutation updateItems($orderItems: [ItemInput], $splitItem: Boolean) {
  updateItems(orderItems: $orderItems, splitItem: $splitItem) @context(provider: "vtex.checkout-graphql"){
		items {
			uniqueId
			quantity
		}
 	}
}

```
Sample variables:
```json
{
  "splitItem": false,
  "orderItems": [
    {
      "index": 1,
      "quantity": 2
    }
  ]
}
```

[Workspace](https://ecom7116--carrefourbr.myvtex.com/_v/private/carrefourbr.carrefour-components@0.35.0/graphiql/v1)

#### Test-proof

![image](https://user-images.githubusercontent.com/51974587/93242741-a32ee480-f75d-11ea-9893-abb66ef6d116.png)


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
