### PR TITLE
Add manualPrice property to Item type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `manualPrice` property to `Item` type.
 
 ## [0.40.0] - 2020-09-24
 ### Added

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -17,6 +17,7 @@ type Item {
   id: ID!
   imageUrls: ImageUrls
   listPrice: Float
+  manualPrice: Float
   measurementUnit: String
   name: String
   offerings: [Offering!]!

--- a/node/clients/checkoutAdmin.ts
+++ b/node/clients/checkoutAdmin.ts
@@ -29,6 +29,14 @@ export class CheckoutAdmin extends JanusClient {
     })
   }
 
+  public orderForm = () => {
+    return this.post<CheckoutOrderForm>(
+      this.routes.orderForm,
+      {},
+      { metric: 'checkout-orderForm' }
+    )
+  }
+
   public setManualPrice = (
     orderFormId: string,
     itemIndex: number,
@@ -40,6 +48,16 @@ export class CheckoutAdmin extends JanusClient {
         price,
       }
     )
+
+  protected post = <T>(url: string, data?: any, config: RequestConfig = {}) => {
+    config.headers = {
+      ...config.headers,
+      ...this.getCommonHeaders(),
+    }
+    return this.http.post<T>(url, data, config).catch(statusToError) as Promise<
+      T
+    >
+  }
 
   protected put = <T>(url: string, data?: any, config: RequestConfig = {}) => {
     config.headers = {
@@ -62,6 +80,7 @@ export class CheckoutAdmin extends JanusClient {
   private get routes() {
     const base = '/api/checkout/pub'
     return {
+      orderForm: `${base}/orderForm`,
       setManualPrice: (orderFormId: string, itemIndex: number) =>
         `${base}/orderForm/${orderFormId}/items/${itemIndex}/price`,
     }

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -34,6 +34,16 @@ export const root = {
   OrderForm: {
     id: prop('orderFormId'),
     marketingData: propOr({}, 'marketingData'),
+    allowManualPrice: async (
+      orderForm: CheckoutOrderForm,
+      _: unknown,
+      ctx: Context
+    ) => {
+      return (
+        (await ctx.clients.checkoutAdmin.orderForm())?.allowManualPrice ||
+        orderForm.allowManualPrice
+      )
+    },
     userType: async (
       orderForm: CheckoutOrderForm,
       __: unknown,

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -39,9 +39,10 @@ export const root = {
       _: unknown,
       ctx: Context
     ) => {
+      const checkoutAdminOrderForm = await ctx.clients.checkoutAdmin.orderForm()
+
       return (
-        (await ctx.clients.checkoutAdmin.orderForm())?.allowManualPrice ||
-        orderForm.allowManualPrice
+        checkoutAdminOrderForm?.allowManualPrice || orderForm.allowManualPrice
       )
     },
     userType: async (

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -109,6 +109,7 @@ declare global {
     parentAssemblyBinding: string | null
     productCategoryIds: string
     priceTags: string[]
+    manualPrice: number
     measurementUnit: string
     additionalInfo: {
       brandName: string


### PR DESCRIPTION
#### What problem is this solving?

This PR adds the property `manualPrice` to `Item` type and, besides that, it also uses the newly created `checkoutAdmin` client in order to provide an `orderForm` with the proper info about `allowManualPrice` property.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- [Make the orderForm query](https://testejeff--checkoutio.myvtex.com/_v/private/vtex.checkout-graphql@0.40.0/graphiql/v1?query=%7B%0A%20%20orderForm%20%7B%0A%20%20%20%20allowManualPrice%0A%20%20%20%20items%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20sellingPrice%0A%20%20%20%20%7D%0A%20%20%20%20userType%0A%20%20%7D%0A%7D)
- Check if `allowManualPrice` is `true`

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Thank you, @lucasecdb ! 🎉 

<!-- Put any relevant information that doesn't fit in the other sections here. -->
