### PR TITLE
Fix error when shippingData in orderForm is null

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,8 +14,6 @@
 - [ ] Updated/created tests (important for bug fixes).
 - [ ] Deleted the workspace after merging this PR (if applicable).
 
-#### Screenshots or example usage
-
 #### Type of changes
 
 <!--- Add a ✔️ where applicable -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error when calculating the shipping info for an user that didn't have
+  `shippingData` filled in their order form.
 
 ## [0.44.0] - 2020-10-06
 ### Added

--- a/node/package.json
+++ b/node/package.json
@@ -25,7 +25,7 @@
     "@vtex/api": "6.36.3",
     "@vtex/test-tools": "^3.1.0",
     "@vtex/tsconfig": "^0.2.0",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.39.1/public/@types/vtex.checkout-graphql",
     "vtex.country-data-settings": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-data-settings@0.2.0/public/@types/vtex.country-data-settings",
     "vtex.graphql-server": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.graphql-server@1.63.0/public/_types/react"

--- a/node/resolvers/shipping.ts
+++ b/node/resolvers/shipping.ts
@@ -76,7 +76,7 @@ export const mutations = {
 
   selectPickupOption: async (
     _: unknown,
-    args: { pickupOptionId: string, itemId: string } & OrderFormIdArgs,
+    args: { pickupOptionId: string; itemId: string } & OrderFormIdArgs,
     ctx: Context
   ) => {
     const { clients, vtex } = ctx

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -12,6 +12,7 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "alwaysStrict": true,
+    "strict": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "strictPropertyInitialization": true,

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -200,7 +200,7 @@ declare global {
       name: string
       value: number
     }>
-    shippingData: ShippingData
+    shippingData: ShippingData | null
     clientProfileData: ClientProfileData | null
     paymentData: PaymentData
     marketingData: OrderFormMarketingData | null

--- a/node/utils/shipping.ts
+++ b/node/utils/shipping.ts
@@ -40,13 +40,13 @@ export const selectShippingOption = ({
   itemId,
   deliveryChannel,
 }: {
-  shippingData: ShippingData
+  shippingData: ShippingData | null
   slaId: string
   itemId?: string
   deliveryChannel: string
 }) => {
-  const logisticsInfoWithSelectedDeliveryOption = shippingData.logisticsInfo.map(
-    (li: LogisticsInfo) => {
+  const logisticsInfoWithSelectedDeliveryOption =
+    shippingData?.logisticsInfo.map((li: LogisticsInfo) => {
       return {
         ...li,
         selectedDeliveryChannel: deliveryChannel,
@@ -56,11 +56,10 @@ export const selectShippingOption = ({
             ? slaId
             : li.selectedSla,
       }
-    }
-  )
+    }) ?? []
 
   const deliveryAddress = getSelectedDeliveryAddress(
-    shippingData.selectedAddresses
+    shippingData?.selectedAddresses ?? []
   )
 
   if (!deliveryAddress) {
@@ -77,9 +76,13 @@ export const selectAddress = ({
   shippingData,
   address,
 }: {
-  shippingData: ShippingData
+  shippingData: ShippingData | null
   address: CheckoutAddress
-}): ShippingData => {
+}): ShippingData | null => {
+  if (!shippingData) {
+    return null
+  }
+
   return {
     ...shippingData,
     selectedAddresses: [address],

--- a/node/utils/shipping.ts
+++ b/node/utils/shipping.ts
@@ -96,15 +96,13 @@ export const getShippingInfo = async ({
     'shippingData' | 'totalizers' | 'orderFormId' | 'value'
   >
 }) => {
-  const logisticsInfo =
-    orderForm.shippingData && orderForm.shippingData.logisticsInfo
+  const logisticsInfo = orderForm.shippingData?.logisticsInfo ?? []
 
   const countries = Array.from(
     new Set(logisticsInfo.flatMap(item => item.shipsTo)).values()
   )
 
-  const availableAddresses =
-    (orderForm.shippingData && orderForm.shippingData.availableAddresses) || []
+  const availableAddresses = orderForm.shippingData?.availableAddresses ?? []
 
   const selectedAddress =
     orderForm.shippingData &&

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6034,7 +6034,12 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@3.8.3, typescript@^3.7.3:
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+typescript@^3.7.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==


### PR DESCRIPTION
#### What problem is this solving?

Fixes an issue with the deploy of #98, where some of the refactor in `utils/shipping.ts` led to an error when the `orderForm.shippingData` was `null`.

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/).

You should remove your cookies to enter the above workspace with a fresh order form.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
