### PR TITLE
add updateOrderFormOpenTextField mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `updateOrderFromOpenTextField` mutation.
 
 ## [0.49.0] - 2020-12-01
 ### Added
@@ -34,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.44.0] - 2020-10-06
 ### Added
-- Optional argument `itemId` on `selectPickupOption` mutation, it can select the 
+- Optional argument `itemId` on `selectPickupOption` mutation, it can select the
   pickup option for an specific itemId
 - New `selectPickupOption` mutation
 - `pickupOptions` property to `Shipping` type
@@ -68,7 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.39.0] - 2020-09-15
 ### Added
-- `splitItem` parameter on `updateItems` mutation. 
+- `splitItem` parameter on `updateItems` mutation.
 
 ## [0.38.0] - 2020-09-11
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -94,4 +94,9 @@ type Mutation {
   clearOrderFormMessages(orderFormId: ID): OrderForm!
     @withOrderFormId
     @cacheControl(scope: PRIVATE)
+
+  updateOrderFormOpenTextField(orderFormId: ID, input: OrderFormOpenTextInput!): OrderForm!
+    @withOrderFormId
+    @cacheControl(scope: PRIVATE)
+
 }

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -14,6 +14,11 @@ type OrderForm {
   clientProfileData: ClientData
   clientPreferencesData: ClientPreferencesData
   allowManualPrice: Boolean
+  openTextField: OpenTextField
+}
+
+type OpenTextField {
+  value: String
 }
 
 enum UserType {
@@ -70,4 +75,8 @@ input ClientPreferencesDataInput {
 enum ItemsOrdinationCriteria {
   name
   add_time
+}
+
+input OrderFormOpenTextInput {
+  value: String
 }

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -137,6 +137,16 @@ export class Checkout extends JanusClient {
       { metric: 'checkout-updateOrderFormClientPreferencesData' }
     )
 
+  public updateOrderFromOpenTextField = (
+    orderFromId: string,
+    openTextField: OpenTextField
+  ) =>
+    this.post<CheckoutOrderForm>(
+      this.routes.attachmentsData(orderFromId, 'openTextField'),
+      openTextField,
+      { metric: 'checkout-updateOrderFromOpenTextField' }
+    )
+
   public addAssemblyOptions = async (
     orderFormId: string,
     itemId: string | number,

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -204,6 +204,10 @@ interface MutationUpdateOrderFormPaymentArgs {
   input: PaymentDataInput
 }
 
+interface MutationUpdateOrderFormOpenTextField {
+  input: OpenTextField
+}
+
 export const mutations = {
   updateOrderFormProfile: async (
     _: unknown,
@@ -262,7 +266,6 @@ export const mutations = {
 
     return orderFormWithPayments
   },
-
   updateItemsOrdination: async (
     _: unknown,
     args: ItemsOrdinationArgs & OrderFormIdArgs,
@@ -297,5 +300,21 @@ export const mutations = {
     const updatedOrderForm = await checkout.clearMessages(orderFormId!)
 
     return updatedOrderForm
+  },
+
+  updateOrderFormOpenTextField: async (
+    _: unknown,
+    args: MutationUpdateOrderFormOpenTextField & OrderFormIdArgs,
+    ctx: Context
+  ): Promise<CheckoutOrderForm> => {
+    const { clients: { checkout }, vtex } = ctx
+    const { orderFormId = vtex.orderFormId, input } = args
+
+    const orderFormWithOpenTextField = await checkout.updateOrderFromOpenTextField(
+      orderFormId!,
+      input
+    )
+
+    return orderFormWithOpenTextField
   },
 }

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -562,4 +562,8 @@ declare global {
     ascending: boolean
     criteria: ItemsOrdinationCriteria
   }
+
+  interface OpenTextField {
+    value?: string
+  }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5693,7 +5693,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?
Make orderform openTextFile accessible

<!--- What is the motivation and context for this change? -->
i need to save a json(as string) in orderForm.

#### How should this be manually tested?
https://workspacename--accountname.myvtex.com/admin/graphql-ide

run mutation
```
mutation {
  updateOrderFormOpenTextField(
    orderFormId: "yourOrderFrmId",
    input: {
      value: "teste"
    }
  ) {
    id
    openTextField {
      value
    }
  }
}
```

~[Workspace](url)~

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
