### PR TITLE
add parentIndex on type Item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `parentItemIndex` on type `Item`.
 
 ## [0.49.0] - 2020-12-01
 ### Added

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -22,7 +22,7 @@ type Item {
   name: String
   offerings: [Offering!]!
   options: [AssemblyOptionType]
-  parentAssemblyBinding: String,
+  parentAssemblyBinding: String
   parentItemIndex: Int
   price: Float
   productCategories: ProductCategoriesObject

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -22,7 +22,8 @@ type Item {
   name: String
   offerings: [Offering!]!
   options: [AssemblyOptionType]
-  parentAssemblyBinding: String
+  parentAssemblyBinding: String,
+  parentItemIndex: Int
   price: Float
   productCategories: ProductCategoriesObject
   productCategoryIds: String


### PR DESCRIPTION
#### What problem is this solving?
Returns the index of the parent item in the orderform

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Just add items with assembly options

![assembly](https://user-images.githubusercontent.com/38354801/99099509-4d3db800-25b9-11eb-8e24-a0c2b8dc8a5b.PNG)


[Workspace](https://gus--acctglobal.myvtex.com/_v/private/vtex.checkout-resources@0.37.0/graphiql/v1?query=query%20orderFormQuery%20%7B%20%0A%09orderForm%20%7B%0A%20%20%20%20id%0A%20%20%20%20items%20%7B%0A%20%20%20%20%20%20parentItemIndex%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=orderFormQuery)

This PR depends on
https://github.com/vtex-apps/checkout-resources/pull/60

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
