### PR TITLE
CHK-464: Add clearOrderFormMessages mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Mutation `clearOrderFormMessages` to clear the messages in the order form.
 
 ## [0.47.0] - 2020-11-13
 ### Changed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -50,8 +50,11 @@ type Mutation {
   selectDeliveryOption(orderFormId: ID, deliveryOptionId: String): OrderForm!
     @withOrderFormId
 
-  selectPickupOption(orderFormId: ID, pickupOptionId: String, itemId: String): OrderForm!
-    @withOrderFormId
+  selectPickupOption(
+    orderFormId: ID
+    pickupOptionId: String
+    itemId: String
+  ): OrderForm! @withOrderFormId
 
   """
   Changes the currently selected address in the shipping data
@@ -82,8 +85,13 @@ type Mutation {
     @withOrderFormId
     @cacheControl(scope: PRIVATE)
 
-  updateItemsOrdination(orderFormId: ID, ascending: Boolean!, criteria: ItemsOrdinationCriteria!): OrderForm!
+  updateItemsOrdination(
+    orderFormId: ID
+    ascending: Boolean!
+    criteria: ItemsOrdinationCriteria!
+  ): OrderForm! @withOrderFormId @cacheControl(scope: PRIVATE)
+
+  clearOrderFormMessages(orderFormId: ID): OrderForm!
     @withOrderFormId
     @cacheControl(scope: PRIVATE)
-
 }

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -265,14 +265,19 @@ export class Checkout extends JanusClient {
   public getProfile = (email: string) =>
     this.get<CheckoutProfile>(this.routes.profile(email))
 
-  public updateItemsOrdination = (orderFormId: string, ascending: boolean, criteria: string) => this.post<CheckoutOrderForm>(
-    this.routes.updateItemsOrdination(orderFormId),
-    {
-      ascending: ascending,
-      criteria: criteria
-    },
-    { metric: 'checkout-orderForm' }
-  )
+  public updateItemsOrdination = (
+    orderFormId: string,
+    ascending: boolean,
+    criteria: string
+  ) =>
+    this.post<CheckoutOrderForm>(
+      this.routes.updateItemsOrdination(orderFormId),
+      {
+        ascending,
+        criteria,
+      },
+      { metric: 'checkout-orderForm' }
+    )
 
   protected get = <T>(url: string, config: RequestConfig = {}) => {
     config.headers = {
@@ -411,8 +416,8 @@ export class Checkout extends JanusClient {
       savePaymentToken: (queryString: string) =>
         `${base}/current-user/payment-tokens/${queryString}`,
       getPaymentSession: () => `${base}/payment-session`,
-      updateItemsOrdination: (orderFormId: string) => `${base}/orderForm/${orderFormId}/itemsOrdination`
+      updateItemsOrdination: (orderFormId: string) =>
+        `${base}/orderForm/${orderFormId}/itemsOrdination`,
     }
   }
-  
 }

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -267,22 +267,35 @@ export const mutations = {
     _: unknown,
     args: ItemsOrdinationArgs & OrderFormIdArgs,
     ctx: Context
-    ): Promise<CheckoutOrderForm> => {
-      
-    const { clients: { checkout }, vtex } = ctx
+  ): Promise<CheckoutOrderForm> => {
     const {
-      ascending,
-      criteria,
-      orderFormId = vtex.orderFormId,
-    } = args
-      
+      clients: { checkout },
+      vtex,
+    } = ctx
+    const { ascending, criteria, orderFormId = vtex.orderFormId } = args
+
     const changeItemsOrdination = await checkout.updateItemsOrdination(
       orderFormId!,
-      ascending, 
+      ascending,
       criteria
     )
 
     return changeItemsOrdination
-  },  
-  
+  },
+
+  clearOrderFormMessages: async (
+    _: unknown,
+    args: OrderFormIdArgs,
+    ctx: Context
+  ) => {
+    const {
+      clients: { checkout },
+      vtex,
+    } = ctx
+    const { orderFormId = vtex.orderFormId } = args
+
+    const updatedOrderForm = await checkout.clearMessages(orderFormId!)
+
+    return updatedOrderForm
+  },
 }


### PR DESCRIPTION
#### What problem is this solving?

Adds the `clearOrderFormMessages` mutation to clear the messages inside the orderForm.

#### How should this be manually tested?

[Workspace](https://toasts--checkoutio.myvtex.com/).

You can see the messages being cleared by adding the first product on the home page shelf and updating its quantity to 50+. You should be able to see the request for this mutation in the devtools network panel.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
