### PR TITLE
Make property additionalInfo optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Pickup point `additionalInfo` is not required anymore.
 
 ## [0.49.0] - 2020-12-01
 ### Added

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -23,7 +23,7 @@ type PickupOption {
   estimate: String!
   isSelected: Boolean!
   friendlyName: String!
-  additionalInfo: String!
+  additionalInfo: String
   storeDistance: Float!
   transitTime: String!
   businessHours: [BusinessHour!]!

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5693,7 +5693,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

The aim of this PR is to make `additionalInfo` property optional. With that,  we'll decrease the number of errors caused by it being required.

See: https://vtex.slack.com/archives/G01917T2293/p1606914979000400

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

N/A

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
