### PR TITLE
created mutation updateOrderFormMarketingData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `updateOrderFormMarketingData` in checkout mutations
+
 ## [0.51.0] - 2020-12-02
 ### Added
 - `updateOrderFromOpenTextField` mutation.

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -99,4 +99,7 @@ type Mutation {
     @withOrderFormId
     @cacheControl(scope: PRIVATE)
 
+  updateOrderFormMarketingData(input: MarketingDataInput!): OrderForm! 
+    @withOrderFormId
+    @cacheControl(scope: PRIVATE)
 }

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -34,6 +34,7 @@ type MarketingData {
   utmiPart: String
   utmiPage: String
   coupon: String
+  marketingTags: [String]
 }
 
 input MarketingDataInput {
@@ -43,6 +44,8 @@ input MarketingDataInput {
   utmiCampaign: String
   utmiPart: String
   utmiPage: String
+  coupon: String
+  marketingTags: [String]
 }
 
 type Totalizer {

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -165,7 +165,11 @@ export const queries = {
     args: OrderFormIdArgs,
     ctx: Context
   ): Promise<CheckoutOrderForm> => {
-    const { clients, vtex, graphql: { cacheControl } } = ctx
+    const {
+      clients,
+      vtex,
+      graphql: { cacheControl },
+    } = ctx
     const { orderFormId = vtex.orderFormId } = args
 
     cacheControl.noCache = true
@@ -206,6 +210,10 @@ interface MutationUpdateOrderFormPaymentArgs {
 
 interface MutationUpdateOrderFormOpenTextField {
   input: OpenTextField
+}
+
+interface MutationUpdateOrderFormMarketingData {
+  input: OrderFormMarketingData
 }
 
 export const mutations = {
@@ -307,7 +315,10 @@ export const mutations = {
     args: MutationUpdateOrderFormOpenTextField & OrderFormIdArgs,
     ctx: Context
   ): Promise<CheckoutOrderForm> => {
-    const { clients: { checkout }, vtex } = ctx
+    const {
+      clients: { checkout },
+      vtex,
+    } = ctx
     const { orderFormId = vtex.orderFormId, input } = args
 
     const orderFormWithOpenTextField = await checkout.updateOrderFromOpenTextField(
@@ -316,5 +327,25 @@ export const mutations = {
     )
 
     return orderFormWithOpenTextField
+  },
+
+  updateOrderFormMarketingData: async (
+    _: unknown,
+    args: MutationUpdateOrderFormMarketingData & OrderFormIdArgs,
+    ctx: Context
+  ): Promise<CheckoutOrderForm> => {
+    const {
+      clients: { checkout },
+      vtex,
+    } = ctx
+
+    const { orderFormId = vtex.orderFormId, input } = args
+
+    const updatedOrderForm = await checkout.updateOrderFormMarketingData(
+      orderFormId!,
+      input
+    )
+
+    return updatedOrderForm
   },
 }


### PR DESCRIPTION
#### What problem is this solving?

Make able to change marketingData on orderForm in VTEX IO environment.

#### How should this be manually tested?

Go to graphql-ide on admin and execute mutation like image below.

[Workspace](https://marketingtags--dzarm.myvtex.com/_v/private/vtex.checkout-graphql@0.51.0/graphiql/v1)

Print - https://prnt.sc/vzb72h

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ x ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
