### PR TITLE
Increase maxReplicas to 120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Increase maxReplicas to 120.
 
 ## [0.52.0] - 2020-12-14
 ### Added

--- a/node/service.json
+++ b/node/service.json
@@ -4,7 +4,7 @@
   "ttl": 43200,
   "timeout": 30,
   "minReplicas": 2,
-  "maxReplicas": 30,
+  "maxReplicas": 120,
   "workers": 4,
   "cpu": 30
 }


### PR DESCRIPTION
As per the BF Investigation of Scalings, I found out that a safer maxReplicas for this app would be 120.

Here's the full list:
https://github.com/vtex/io-infra-tools/blob/master/bf-2020/critical-apps/scalings.txt#L12