### PR TITLE
Add mutation updateOrderFormMarketingData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Mutation `updateOrderFormMarketingData`.
 
 ## [0.52.1] - 2020-12-14
 ### Changed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -99,4 +99,7 @@ type Mutation {
     @withOrderFormId
     @cacheControl(scope: PRIVATE)
 
+  updateOrderFormMarketingData(input: MarketingDataInput!): OrderForm! 
+    @withOrderFormId
+    @cacheControl(scope: PRIVATE)
 }

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -7,7 +7,7 @@ type OrderForm {
   userType: UserType
   shipping: Shipping!
   marketingData: MarketingData!
-  totalizers: [Totalizer]!
+  totalizers: [Totalizer!]!
   value: Float!
   messages: OrderFormMessages!
   paymentData: PaymentData!
@@ -34,6 +34,7 @@ type MarketingData {
   utmiPart: String
   utmiPage: String
   coupon: String
+  marketingTags: [String!]!
 }
 
 input MarketingDataInput {
@@ -43,6 +44,8 @@ input MarketingDataInput {
   utmiCampaign: String
   utmiPart: String
   utmiPage: String
+  coupon: String
+  marketingTags: [String!]!
 }
 
 type Totalizer {
@@ -52,8 +55,8 @@ type Totalizer {
 }
 
 type OrderFormMessages {
-  couponMessages: [Message]!
-  generalMessages: [Message]!
+  couponMessages: [Message!]!
+  generalMessages: [Message!]!
 }
 
 type Message {

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -165,7 +165,11 @@ export const queries = {
     args: OrderFormIdArgs,
     ctx: Context
   ): Promise<CheckoutOrderForm> => {
-    const { clients, vtex, graphql: { cacheControl } } = ctx
+    const {
+      clients,
+      vtex,
+      graphql: { cacheControl },
+    } = ctx
     const { orderFormId = vtex.orderFormId } = args
 
     cacheControl.noCache = true
@@ -206,6 +210,10 @@ interface MutationUpdateOrderFormPaymentArgs {
 
 interface MutationUpdateOrderFormOpenTextField {
   input: OpenTextField
+}
+
+interface MutationUpdateOrderFormMarketingData {
+  input: OrderFormMarketingData
 }
 
 export const mutations = {
@@ -307,7 +315,10 @@ export const mutations = {
     args: MutationUpdateOrderFormOpenTextField & OrderFormIdArgs,
     ctx: Context
   ): Promise<CheckoutOrderForm> => {
-    const { clients: { checkout }, vtex } = ctx
+    const {
+      clients: { checkout },
+      vtex,
+    } = ctx
     const { orderFormId = vtex.orderFormId, input } = args
 
     const orderFormWithOpenTextField = await checkout.updateOrderFromOpenTextField(
@@ -316,5 +327,25 @@ export const mutations = {
     )
 
     return orderFormWithOpenTextField
+  },
+
+  updateOrderFormMarketingData: async (
+    _: unknown,
+    args: MutationUpdateOrderFormMarketingData & OrderFormIdArgs,
+    ctx: Context
+  ): Promise<CheckoutOrderForm> => {
+    const {
+      clients: { checkout },
+      vtex,
+    } = ctx
+
+    const { orderFormId = vtex.orderFormId, input } = args
+
+    const updatedOrderForm = await checkout.updateOrderFormMarketingData(
+      orderFormId!,
+      input
+    )
+
+    return updatedOrderForm
   },
 }


### PR DESCRIPTION
#### What problem is this solving?

Adds possibility of changing the orderForm marketing tags.

#### How should this be manually tested?

[Workspace](https://marketingtags--checkoutio.myvtex.com/_v/private/vtex.checkout-graphql@0.52.1/graphiql/v1).

Run the following mutation

```graphql
mutation {
  updateOrderFormMarketingData(input: { marketingTags: ["free_shipping"] }) {
    marketingData {
      marketingTags
    }
  }
}
```

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Moved from #111.
