### PR TITLE
Update marketingTags to be optional in marketing data input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Field `marketingTags` is optional in marketing data input.
 
 ## [0.53.0] - 2020-12-22
 ### Added

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -34,7 +34,7 @@ type MarketingData {
   utmiPart: String
   utmiPage: String
   coupon: String
-  marketingTags: [String!]!
+  marketingTags: [String!]
 }
 
 input MarketingDataInput {
@@ -45,7 +45,7 @@ input MarketingDataInput {
   utmiPart: String
   utmiPage: String
   coupon: String
-  marketingTags: [String!]!
+  marketingTags: [String!]
 }
 
 type Totalizer {


### PR DESCRIPTION
#### What problem is this solving?

We shouldn't have made the new `marketingTags` property as required in the marketing data input type, because some stores may be sending the marketing data as an empty object.

#### How should this be manually tested?

No workspace, just some typing changes.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
