### PR TITLE
Add storePreferencesData to orderForm query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- `storePreferencesData` to `orderForm` query
 ## [0.53.0] - 2020-12-22
 ### Added
 - Mutation `updateOrderFormMarketingData`.

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -15,6 +15,22 @@ type OrderForm {
   clientPreferencesData: ClientPreferencesData
   allowManualPrice: Boolean
   openTextField: OpenTextField
+  storePreferencesData: StorePreferencesData
+}
+
+type StorePreferencesData {
+  countryCode: String
+  currencyCode: String
+  timeZone: String
+  currencyFormatInfo: CurrencyFormatInfo
+  currencySymbol: String
+}
+
+type CurrencyFormatInfo {
+  currencyDecimalDigits: Int
+  currencyDecimalSeparator: String
+  currencyGroupSeparator: String
+  startsWithCurrencySymbol: Boolean
 }
 
 type OpenTextField {

--- a/node/package.json
+++ b/node/package.json
@@ -22,7 +22,7 @@
     "@types/lodash": "^4.14.138",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.37.0",
+    "@vtex/api": "6.37.1",
     "@vtex/test-tools": "^3.1.0",
     "@vtex/tsconfig": "^0.2.0",
     "typescript": "3.9.7",

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -34,6 +34,7 @@ export const root = {
   OrderForm: {
     id: prop('orderFormId'),
     marketingData: propOr({}, 'marketingData'),
+    storePreferencesData: propOr({}, 'storePreferencesData'),
     allowManualPrice: async (
       orderForm: CheckoutOrderForm,
       _: unknown,

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1597,10 +1597,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@6.37.0":
-  version "6.37.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.0.tgz#a07e6adbfc02866f901cf0cfff2155f2c279adc5"
-  integrity sha512-Vy970ZfgOttrxeiJW2oM8rQ0E8t/HE5cQhbGIawfJsu35HEWA9NnWRSR3bdLMczT9oYIY9QwE8IfdU4b44dhKw==
+"@vtex/api@6.37.1":
+  version "6.37.1"
+  resolved "https://registry.npmjs.org/@vtex/api/-/api-6.37.1.tgz#d6ded4f4a98e10596729af7097cff18be43a0e54"
+  integrity sha512-24BaVHCIbkC84UWAlGPuTnUYIFngOpeRa4u/6KCJDnir5GXjoCWAkj4E7OoQ2uvBy/uvs9X2+DIkqtiz1x5bvw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -5693,7 +5693,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
To be able to fetch `storePreferencesData` in the `orderForm` query. It is [available](https://github.com/vtex-apps/store-graphql/blob/master/graphql/types/OrderForm.graphql#L23) in store-graphql 

#### How should this be manually tested?

[Workspace](https://grispref--demostore.myvtex.com/_v/private/vtex.checkout-graphql@0.53.0/graphiql/v1?query=%7B%0A%20%20orderForm(orderFormId%3A%2214a7b62c9cb0490287396504b1390943%22)%7B%0A%20%20%20%20allowManualPrice%0A%20%20%20%20storePreferencesData%20%7B%0A%20%20%20%20%20%20countryCode%0A%20%20%20%20%20%20currencyCode%0A%20%20%20%20%20%20timeZone%0A%20%20%20%20%20%20currencySymbol%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)

#### Checklist/Reminders

- [] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
