### PR TITLE
Fix admin login associated with orderForm on myvtex.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- OrderForm with admin login on `myvtex.com` domain.
 
 ## [0.55.1] - 2020-12-23
 ### Changed


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes the API storing the user's admin login (such as email address, and other infos, if the email has already made a purchase on the account), by skipping the call using the `checkoutAdmin` client if the user doesn't have call center operator permissions.

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/cart/add?sku=312&sc=2).

If your user doesn't have the call center operator profile, if you proceed to checkout you should be asked to fill the email address.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
