### PR TITLE
Update translatable orderForm fields with appropriate directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated some orderForm fields to be translatable.
 
 ## [0.55.2] - 2021-01-19
 ### Fixed

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -19,7 +19,7 @@ type Item {
   listPrice: Float
   manualPrice: Float
   measurementUnit: String
-  name: String
+  name: String @translatableV2
   offerings: [Offering!]!
   options: [AssemblyOptionType]
   parentAssemblyBinding: String
@@ -40,7 +40,7 @@ type Item {
   seller: String
   sellingPrice: Float
   sellingPriceWithAssemblies: Float
-  skuName: String
+  skuName: String @translatableV2
   skuSpecifications: [SKUSpecification!]!
   uniqueId: String!
   unitMultiplier: Float
@@ -62,7 +62,7 @@ type AssemblyOptionItem {
 type RemovedOptionItem {
   initialQuantity: Int
   removedQuantity: Int
-  name: String
+  name: String @translatableV2
 }
 
 type AddedOptionItem {
@@ -83,7 +83,7 @@ type CompositionItem {
 }
 
 type ItemAdditionalInfo {
-  brandName: String
+  brandName: String @translatableV2
 }
 
 type SKUSpecification {
@@ -102,7 +102,7 @@ type AssemblyOptionType {
 
 type Offering {
   id: String!
-  name: String!
+  name: String! @translatableV2
   price: Int!
   type: String!
   attachmentOfferings: [AttachmentOffering!]!
@@ -111,7 +111,7 @@ type Offering {
 scalar AttachmentSchema
 
 type AttachmentOffering {
-  name: String
+  name: String @translatableV2
   required: Boolean
   schema: AttachmentSchema
 }
@@ -119,7 +119,7 @@ type AttachmentOffering {
 scalar AttachmentContent
 
 type Attachment {
-  name: String
+  name: String @translatableV2
   content: AttachmentContent
 }
 

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -66,7 +66,7 @@ input MarketingDataInput {
 
 type Totalizer {
   id: String!
-  name: String
+  name: String @translatableV2
   value: Float!
 }
 
@@ -78,7 +78,7 @@ type OrderFormMessages {
 type Message {
   code: String
   status: String
-  text: String
+  text: String @translatableV2
 }
 
 type ClientPreferencesData {

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -22,8 +22,8 @@ type PickupOption {
   price: Int!
   estimate: String!
   isSelected: Boolean!
-  friendlyName: String!
-  additionalInfo: String
+  friendlyName: String! @translatableV2
+  additionalInfo: String @translatableV2
   storeDistance: Float
   transitTime: String!
   businessHours: [BusinessHour!]!

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "vtex.country-data-settings": "0.x",
-    "vtex.graphql-server": "1.x"
+    "vtex.graphql-server": "1.x",
+    "vtex.messages": "1.x"
   },
   "credentialType": "absolute",
   "mustUpdateAt": "2019-11-05",
@@ -18,6 +19,9 @@
     "smartcheckout"
   ],
   "policies": [
+    {
+      "name": "vtex.messages:translate-messages"
+    },
     {
       "name": "outbound-access",
       "attrs": {

--- a/node/package.json
+++ b/node/package.json
@@ -22,7 +22,7 @@
     "@types/lodash": "^4.14.138",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.37.1",
+    "@vtex/api": "6.39.0",
     "@vtex/test-tools": "^3.1.0",
     "@vtex/tsconfig": "^0.2.0",
     "typescript": "3.9.7",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1597,10 +1597,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@6.37.1":
-  version "6.37.1"
-  resolved "https://registry.npmjs.org/@vtex/api/-/api-6.37.1.tgz#d6ded4f4a98e10596729af7097cff18be43a0e54"
-  integrity sha512-24BaVHCIbkC84UWAlGPuTnUYIFngOpeRa4u/6KCJDnir5GXjoCWAkj4E7OoQ2uvBy/uvs9X2+DIkqtiz1x5bvw==
+"@vtex/api@6.39.0":
+  version "6.39.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.0.tgz#5f5b6c54713f4e3c6671d86feb3faec543b449f2"
+  integrity sha512-YoHLnMb0V2LMxoXQgIskbsHNkG/TprXjsE60RItHNjALx2b6/+gYFLSa8x/sJp+O6OJQQT3pSkFT7Ff5A8ER9g==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -5693,7 +5693,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Updates the translatable orderForm fields (such as product and pickup names, and totalizers) with the `@translatableV2` directive, so they are automatically translated by the messages service when the store culture info changes.

#### How should this be manually tested?

[Workspace](http://lucas--checkoutio.myvtex.com/cart/add?sku=285).

You can test these changes by appending the `?cultureInfo=ja-JP` to the URL and verifying the product names in the list are properly translated (you can use other languages as well).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
