### PR TITLE
Update to use productName and SKU name from search-graphql query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Reuse Product and SKU name from `search-graphql` query to translate product names in
+  multi-binding stores.
 
 ## [0.56.1] - 2021-02-04
 ### Fixed

--- a/node/clients/graphqlServer.ts
+++ b/node/clients/graphqlServer.ts
@@ -7,8 +7,6 @@ import {
   Serializable,
 } from '@vtex/api'
 
-import { ProductArgs } from './searchGraphQL/productQuery'
-
 export class GraphQLServer extends AppClient {
   protected graphql: GraphQLClient
 
@@ -17,13 +15,13 @@ export class GraphQLServer extends AppClient {
     this.graphql = new GraphQLClient(this.http)
   }
 
-  public query = async <T extends Serializable>(
+  public query = async <TResponse extends Serializable, TArgs extends object>(
     query: string,
     variables: any,
     extensions: any,
     config: RequestConfig
   ) => {
-    return this.graphql.query<T, ProductArgs>(
+    return this.graphql.query<TResponse, TArgs>(
       {
         extensions,
         query,

--- a/node/clients/searchGraphQL/index.ts
+++ b/node/clients/searchGraphQL/index.ts
@@ -1,10 +1,12 @@
-import { Serializable } from '@vtex/api'
+import { InstanceOptions, IOContext } from '@vtex/api'
+import DataLoader from 'dataloader'
 
 import { GraphQLServer } from '../graphqlServer'
 import {
   ProductArgs,
   query as productQuery,
   ProductResponse,
+  ProductsByIdentifierResponse,
 } from './productQuery'
 
 const extensions = {
@@ -15,8 +17,31 @@ const extensions = {
 }
 
 export class SearchGraphQL extends GraphQLServer {
-  public product = <T extends Serializable = ProductResponse>(
-    variables: ProductArgs,
-    query: string = productQuery
-  ) => this.query<T>(query, variables, extensions, { metric: 'get-product' })
+  private productLoader: DataLoader<string, ProductResponse>
+
+  constructor(ctx: IOContext, opts?: InstanceOptions) {
+    super(ctx, opts)
+
+    this.productLoader = new DataLoader(async keys => {
+      const { data, errors } = await this.query<
+        ProductsByIdentifierResponse,
+        ProductArgs
+      >(productQuery, { values: keys }, extensions, { metric: 'get-product' })
+
+      if (errors && errors.length > 0) {
+        const [error] = errors
+
+        return keys.map(() => error.originalError!)
+      }
+
+      return keys.map(
+        id =>
+          data?.productsByIdentifier.find(
+            product => product.productId === id
+          ) ?? new Error('Product not found')
+      )
+    })
+  }
+
+  public product = (productId: string) => this.productLoader.load(productId)
 }

--- a/node/clients/searchGraphQL/productQuery.ts
+++ b/node/clients/searchGraphQL/productQuery.ts
@@ -1,31 +1,29 @@
 export interface ProductResponse {
-  product: {
-    productName: string
-    items: Array<{
-      itemId: string
+  productName: string
+  productId: string
+  items: Array<{
+    itemId: string
+    name: string
+    variations: Array<{
       name: string
-      variations: Array<{
-        name: string
-        values: string[]
-      }>
+      values: string[]
     }>
-  }
+  }>
+}
+
+export interface ProductsByIdentifierResponse {
+  productsByIdentifier: ProductResponse[]
 }
 
 export interface ProductArgs {
-  identifier?: ProductUniqueIdentifier
-  slug?: string
-}
-
-interface ProductUniqueIdentifier {
-  field: 'id' | 'slug' | 'ean' | 'reference' | 'sku'
-  value: string
+  values: string[]
 }
 
 export const query = `
-query Product($identifier: ProductUniqueIdentifier, $slug: String) {
-  product(identifier: $identifier, slug: $slug) {
+query Product($values: [ID!]!) {
+  productsByIdentifier(field: id, values: $values) {
     productName
+    productId
     items {
       itemId
       name

--- a/node/package.json
+++ b/node/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "atob": "^2.1.2",
     "cookie": "^0.4.0",
+    "dataloader": "^2.0.0",
     "graphql": "^14.0.0",
     "graphql-tools": "^4.0.0",
     "lodash": "^4.17.15",
@@ -22,7 +23,7 @@
     "@types/lodash": "^4.14.138",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.39.0",
+    "@vtex/api": "6.39.1",
     "@vtex/test-tools": "^3.1.0",
     "@vtex/tsconfig": "^0.2.0",
     "typescript": "3.9.7",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1597,10 +1597,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@6.39.0":
-  version "6.39.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.0.tgz#5f5b6c54713f4e3c6671d86feb3faec543b449f2"
-  integrity sha512-YoHLnMb0V2LMxoXQgIskbsHNkG/TprXjsE60RItHNjALx2b6/+gYFLSa8x/sJp+O6OJQQT3pSkFT7Ff5A8ER9g==
+"@vtex/api@6.39.1":
+  version "6.39.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.1.tgz#ad675cf46404b0d21476ac441626843b6950c4a2"
+  integrity sha512-w3FghXguk4b+bOSOihB8I4+gGt7JljRCXFgirK9XiHDOr+uPsUEGhC4JeeQ42aBIEQeyGmQQOsyvZ+qZp2C/oA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -2576,6 +2576,11 @@ dataloader@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
   integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
+
+dataloader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
+  integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
 
 debug@=3.1.0, debug@~3.1.0:
   version "3.1.0"
@@ -5693,7 +5698,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

This will solve the issue we were seeing in multi-binding stores where the product names were not being translated according to the current user binding. We will use from now on the name provided by `search-graphql`, which already have been setup to work correctly with this kind of scenario, and won't rely on the automated translation that we were doing before (which wasn't working anyway).

#### How should this be manually tested?

[Workspace](https://chktrad--muji.myvtex.com/porcelaincandleholderl/p)

To test you can add the product in the link above to you cart and change the `__bindingAddress` URL and see the product name translated in the minicart. You can also add other products to the cart to verify they work as well.

A few addresses you can use to test this:

- `www.mujionline.eu/uk`
- `www.mujionline.eu/de`
- `www.mujionline.eu/fi`
- `www.mujionline.eu/se`
- `www.mujionline.eu/dk`

Be aware that some products don't exist cross-binding, and for those cases (where they have the name in english) you can ignore them.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
