### PR TITLE
Fix sending index on add to cart operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove item index in `addToCart` mutation.
 
-## [0.57.0] - 2021-03-23
-
+## [0.57.0] - 2021-03-23 [YANKED]
 ### Added
 - Parameter `allowOutdatedData` to `addToCart` mutation.
 

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -43,15 +43,20 @@ export class Checkout extends JanusClient {
     return this.get<PaymentSession>(this.routes.getPaymentSession())
   }
 
-  public addItem = (orderFormId: string, items: any, salesChannel?: string, allowOutdatedData?: string[]) =>
+  public addItem = (
+    orderFormId: string,
+    items: Array<Omit<OrderFormItemInput, 'uniqueId' | 'index' | 'options'>>,
+    salesChannel?: string,
+    allowOutdatedData?: string[]
+  ) =>
     this.patch<CheckoutOrderForm>(
       this.routes.addItem(
         orderFormId,
         this.getChannelQueryString(salesChannel)
       ),
-      { 
+      {
         orderItems: items,
-        allowedOutdatedData: allowOutdatedData
+        allowedOutdatedData: allowOutdatedData,
       },
       { metric: 'checkout-addItem' }
     )
@@ -77,7 +82,7 @@ export class Checkout extends JanusClient {
 
   public updateItems = (
     orderFormId: string,
-    orderItems: any,
+    orderItems: Array<Omit<OrderFormItemInput, 'id'>>,
     splitItem: boolean
   ) =>
     this.post<CheckoutOrderForm>(

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -85,7 +85,7 @@ export const mutations = {
     args: {
       items: OrderFormItemInput[]
       marketingData: Partial<OrderFormMarketingData>
-      salesChannel?: string,
+      salesChannel?: string
       allowOutdatedData?: string[]
     } & OrderFormIdArgs,
     ctx: Context
@@ -100,7 +100,7 @@ export const mutations = {
       items,
       marketingData = {},
       salesChannel,
-      allowOutdatedData
+      allowOutdatedData,
     } = args
 
     const { checkout } = clients
@@ -108,7 +108,9 @@ export const mutations = {
       Object.keys(marketingData ?? {}).length > 0
 
     const { items: previousItems } = await checkout.orderForm(orderFormId!)
-    const cleanItems = items.map(({ options, ...rest }) => rest)
+    const cleanItems = items.map(
+      ({ options, index, uniqueId, ...rest }) => rest
+    )
     const withOptions = items.filter(
       ({ options }) => !!options && options.length > 0
     )
@@ -170,7 +172,9 @@ export const mutations = {
     const { orderFormId = vtex.orderFormId, orderItems, splitItem } = args
     const { checkout } = clients
 
-    if (orderItems.some((item: OrderFormItemInput) => !item.index)) {
+    const cleanItems = orderItems.map(({ id, ...rest }) => rest)
+
+    if (cleanItems.some((item: OrderFormItemInput) => !item.index)) {
       const orderForm = await checkout.orderForm(orderFormId!)
 
       const idToIndex = orderForm.items.reduce(
@@ -183,7 +187,7 @@ export const mutations = {
         {} as Record<string, number>
       )
 
-      orderItems.forEach((item: OrderFormItemInput) => {
+      cleanItems.forEach((item: OrderFormItemInput) => {
         if (!item.index && item.uniqueId) {
           item.index = idToIndex[item.uniqueId]
         }
@@ -192,7 +196,7 @@ export const mutations = {
 
     const newOrderForm = await clients.checkout.updateItems(
       orderFormId!,
-      orderItems,
+      cleanItems,
       splitItem
     )
 


### PR DESCRIPTION
#### What problem is this solving?

Removes the `index` and `uniqueId` properties from the items object in the `addToCart` mutation, to avoid API errors.

#### How should this be manually tested?

[Workspace](https://lucas--ioqa.myvtex.com)

Add the "Garrafa Cypress" product to your cart and refresh the page, the bottle should be in your cart.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
