### PR TITLE
Support for 'subscriptionData'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `subscriptionData` property in the `orderForm` would never be updated.
 
 ## [0.57.1] - 2021-03-24
 ### Fixed

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -158,6 +158,16 @@ export class Checkout extends JanusClient {
       { metric: 'checkout-updateOrderFromOpenTextField' }
     )
 
+  public updateSubscriptionDataField = (
+    orderFormId: string,
+    subscriptionData: SubscriptionData
+  ) =>
+    this.post<CheckoutOrderForm>(
+      this.routes.attachmentsData(orderFormId, 'subscriptionData'),
+      subscriptionData,
+      { metric: 'checkout-updateSubscriptionDataField' }
+    )
+
   public addAssemblyOptions = async (
     orderFormId: string,
     itemId: string | number,

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -161,7 +161,9 @@ export const mutations = {
           options: itemWithOptions.options as AssemblyOptionInput[],
         }))
         .filter(item =>
-          Boolean(item?.options?.[0].assemblyId.includes('vtex.subscription'))
+          item.options.some(option =>
+            option.assemblyId.includes('vtex.subscription')
+          )
         )
 
       const newSubscriptionDataEntries = generateSubscriptionDataEntry(

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -118,7 +118,7 @@ export const mutations = {
 
     const subscriptionOptionsOnly = withOptions
       .map(itemWithOptions => ({
-        itemIndex: itemWithOptions.index as number,
+        itemIndex: (itemWithOptions.index as number) + previousItems.length,
         options: itemWithOptions.options as AssemblyOptionInput[],
       }))
       .filter(item =>
@@ -168,15 +168,13 @@ export const mutations = {
         previousItems
       )
 
-      const updatedSubscriptionData = newOrderForm.subscriptionData
-        ? {
-            subscriptions: newOrderForm.subscriptionData.subscriptions.concat(
+      const updatedSubscriptionData = {
+        subscriptions: newOrderForm.subscriptionData
+          ? newOrderForm.subscriptionData.subscriptions.concat(
               newSubscriptionDataEntries
-            ),
-          }
-        : {
-            subscriptions: newSubscriptionDataEntries,
-          }
+            )
+          : newSubscriptionDataEntries,
+      }
 
       await checkout.updateSubscriptionDataField(
         orderFormId!,

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -3,10 +3,7 @@ import { Logger } from '@vtex/api'
 import { SearchGraphQL } from '../clients/searchGraphQL'
 import { fixImageUrl } from '../utils/image'
 import { addOptionsForItems } from '../utils/attachmentsHelpers'
-import {
-  adjustSubscriptionItemIndexes,
-  generateSubscriptionDataEntry,
-} from '../utils/subscriptions'
+import { generateSubscriptionDataEntry } from '../utils/subscriptions'
 import { OrderFormIdArgs } from '../utils/args'
 
 const getProductInfo = async (
@@ -229,36 +226,6 @@ export const mutations = {
       cleanItems,
       splitItem
     )
-
-    if (
-      newOrderForm.subscriptionData &&
-      newOrderForm.subscriptionData.subscriptions.length > 0
-    ) {
-      const removedItemIndexes = cleanItems
-        .map(item => item.index)
-        .filter(Boolean)
-
-      const currentSubscriptionDataEntries =
-        newOrderForm.subscriptionData.subscriptions
-
-      const remainingSubscriptions = currentSubscriptionDataEntries.filter(
-        subscription => !removedItemIndexes.includes(subscription.itemIndex)
-      )
-
-      const newSubscriptionData = {
-        subscriptions: adjustSubscriptionItemIndexes(
-          remainingSubscriptions,
-          removedItemIndexes as number[]
-        ),
-      }
-
-      const updatedOrderForm = await checkout.updateSubscriptionDataField(
-        orderFormId!,
-        newSubscriptionData
-      )
-
-      return updatedOrderForm
-    }
 
     return newOrderForm
   },

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -172,6 +172,23 @@ declare global {
     composition: Composition | null
   }
 
+  interface SubscriptionDataEntry {
+    executionCount: number
+    itemIndex: number
+    plan: {
+      frequency: {
+        interval: number
+        periodicity: 'YEAR' | 'MONTH' | 'WEEK' | 'DAY'
+      }
+      type: string
+      validity: {}
+    }
+  }
+
+  interface SubscriptionData {
+    subscriptions: SubscriptionDataEntry[]
+  }
+
   interface MetadataItem {
     id: string
     name: string
@@ -260,7 +277,7 @@ declare global {
       rateAndBenefitsIdentifiers: any[]
       teaser: any[]
     }
-    subscriptionData: any | null
+    subscriptionData: SubscriptionData | null
     itemsOrdination: any | null
   }
 

--- a/node/utils/subscriptions.ts
+++ b/node/utils/subscriptions.ts
@@ -32,10 +32,18 @@ export function generateSubscriptionDataEntry(
   const defaultExecutionCount = 0
 
   const subscriptionDataEntries = subscriptionsFromAssemblyOptions.map(item => {
-    const { itemIndex } = item
+    const { itemIndex, options } = item
+
+    const subscriptionFrequencyOption = options.find(option =>
+      Boolean(option.inputValues[SUBSCRIPTION_KEY_FREQUENCY])
+    )
+
+    if (!subscriptionFrequencyOption) {
+      return null
+    }
 
     const planFrequency = parseFrequency(
-      item.options?.[0].inputValues[SUBSCRIPTION_KEY_FREQUENCY]
+      subscriptionFrequencyOption.inputValues[SUBSCRIPTION_KEY_FREQUENCY]
     )
 
     if (!planFrequency) {

--- a/node/utils/subscriptions.ts
+++ b/node/utils/subscriptions.ts
@@ -5,9 +5,7 @@ const SUBSCRIPTION_KEY_PREFIX = `${SUBSCRIPTION_PREFIX}.key`
 
 const SUBSCRIPTION_KEY_FREQUENCY = `${SUBSCRIPTION_KEY_PREFIX}.frequency`
 
-export function parseFrequency(frequency?: string) {
-  if (frequency == null) return
-
+export function parseFrequency(frequency: string) {
   const match = frequency.match(FREQUENCY_PATTERN)
 
   if (!match) {
@@ -40,8 +38,12 @@ export function generateSubscriptionDataEntry(
       item.options?.[0].inputValues[SUBSCRIPTION_KEY_FREQUENCY]
     )
 
+    if (!planFrequency) {
+      return null
+    }
+
     const subscriptionPlan = {
-      frequency: planFrequency!,
+      frequency: planFrequency,
       type: planType,
       validity: {},
     }
@@ -53,5 +55,8 @@ export function generateSubscriptionDataEntry(
     }
   })
 
-  return subscriptionDataEntries
+  // Remove null entries caused by invalid frequencies
+  const validSubscriptionDataEntries = subscriptionDataEntries.filter(Boolean)
+
+  return validSubscriptionDataEntries as SubscriptionDataEntry[]
 }

--- a/node/utils/subscriptions.ts
+++ b/node/utils/subscriptions.ts
@@ -60,3 +60,20 @@ export function generateSubscriptionDataEntry(
 
   return validSubscriptionDataEntries as SubscriptionDataEntry[]
 }
+
+export function adjustSubscriptionItemIndexes(
+  subscriptions: SubscriptionDataEntry[],
+  removedIndexes: number[]
+) {
+  const updatedSubscriptions = subscriptions
+
+  removedIndexes.forEach(removedIdx => {
+    subscriptions.forEach((subscription, idx) => {
+      if (subscription.itemIndex > removedIdx) {
+        updatedSubscriptions[idx].itemIndex--
+      }
+    })
+  })
+
+  return updatedSubscriptions
+}

--- a/node/utils/subscriptions.ts
+++ b/node/utils/subscriptions.ts
@@ -60,20 +60,3 @@ export function generateSubscriptionDataEntry(
 
   return validSubscriptionDataEntries as SubscriptionDataEntry[]
 }
-
-export function adjustSubscriptionItemIndexes(
-  subscriptions: SubscriptionDataEntry[],
-  removedIndexes: number[]
-) {
-  const updatedSubscriptions = subscriptions
-
-  removedIndexes.forEach(removedIdx => {
-    subscriptions.forEach((subscription, idx) => {
-      if (subscription.itemIndex > removedIdx) {
-        updatedSubscriptions[idx].itemIndex--
-      }
-    })
-  })
-
-  return updatedSubscriptions
-}

--- a/node/utils/subscriptions.ts
+++ b/node/utils/subscriptions.ts
@@ -1,0 +1,57 @@
+const FREQUENCY_PATTERN = /(\d{1,3})?\s*(\w*?)(?:$|s|ly)/i
+
+const SUBSCRIPTION_PREFIX = `vtex.subscription`
+const SUBSCRIPTION_KEY_PREFIX = `${SUBSCRIPTION_PREFIX}.key`
+
+const SUBSCRIPTION_KEY_FREQUENCY = `${SUBSCRIPTION_KEY_PREFIX}.frequency`
+
+export function parseFrequency(frequency?: string) {
+  if (frequency == null) return
+
+  const match = frequency.match(FREQUENCY_PATTERN)
+
+  if (!match) {
+    return
+  }
+
+  const [, count = '1', type] = match
+
+  if (!type) return
+
+  return {
+    interval: +count,
+    periodicity: type.toUpperCase(),
+  } as SubscriptionDataEntry['plan']['frequency']
+}
+
+export function generateSubscriptionDataEntry(
+  subscriptionsFromAssemblyOptions: Array<{
+    itemIndex: number
+    options: AssemblyOptionInput[]
+  }>
+): SubscriptionDataEntry[] {
+  const planType = 'RECURRING_PAYMENT'
+  const defaultExecutionCount = 0
+
+  const subscriptionDataEntries = subscriptionsFromAssemblyOptions.map(item => {
+    const { itemIndex } = item
+
+    const planFrequency = parseFrequency(
+      item.options?.[0].inputValues[SUBSCRIPTION_KEY_FREQUENCY]
+    )
+
+    const subscriptionPlan = {
+      frequency: planFrequency!,
+      type: planType,
+      validity: {},
+    }
+
+    return {
+      executionCount: defaultExecutionCount,
+      itemIndex,
+      plan: subscriptionPlan,
+    }
+  })
+
+  return subscriptionDataEntries
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5698,7 +5698,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

`checkout-graphql` would never update the `subscriptionData` property in the current `orderForm`. Due to this property never being filled, promotions that should've been applied to products with subscriptions attached to them are not working properly.

The issue can be visualized [in this Loom clip](https://www.loom.com/share/ad5b1d6411f640aeb6d48d7a37d13555).

#### How should this be manually tested?

1. Go to this [Workspace](https://victorvtex--emekanwosu.myvtex.com/powerade-sports-drink-electrolyte-enhanced-mountain-berry-blast/p).
2. Add a subscription attachment to the product.
3. Add the product to the cart. You should notice that the price you see for the item has been discounted.
4. Proceed to checkout, there should be a promotion being applied, and each product should be

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

This issue was reported in the following Slack message: https://vtex.slack.com/archives/C91LXBHLK/p1616165466086100.

Related Jira story -> https://vtex-dev.atlassian.net/browse/IOSF-142