### PR TITLE
Feat/item is gift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Field `isGift` to `Item` type.
+
 ## [0.57.2] - 2021-04-05
 ### Fixed
 - `subscriptionData` property in the `orderForm` would never be updated.

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -45,7 +45,7 @@ type Item {
   uniqueId: String!
   unitMultiplier: Float
   priceTags: [PriceTag!]!
-  isGift: Boolean
+  isGift: Boolean!
 }
 
 type ImageUrls {

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -45,6 +45,7 @@ type Item {
   uniqueId: String!
   unitMultiplier: Float
   priceTags: [PriceTag!]!
+  isGift: Boolean
 }
 
 type ImageUrls {

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -465,6 +465,7 @@ declare global {
       at2x: string
       at3x: string
     }
+    isGift: boolean
     listPrice: number
     measurementUnit: string
     name: string


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
This code brings the `isGift` field into the `Item` query type. It supports a development of a feature request by Whirlpool, an European T1 client. The feature is in this [PR](https://github.com/vtex-apps/order-items/pull/42).

#### How should this be manually tested?

This [workspace](https://giftcart--itwhirlpool.myvtex.com) has this branch linked. Using the GraphQL IDE, it's possible to query this order `9a0266a45a8e4bac81d7be64b0c75959` that has an gift on it.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
