### PR TITLE
Add customData field to orderForm

### DIFF
--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -2,6 +2,7 @@ type OrderForm {
   id: ID!
   items: [Item!]!
   canEditData: Boolean!
+  customData: CustomData
   loggedIn: Boolean!
   userProfileId: String
   userType: UserType
@@ -31,6 +32,17 @@ type CurrencyFormatInfo {
   currencyDecimalSeparator: String
   currencyGroupSeparator: String
   startsWithCurrencySymbol: Boolean
+}
+
+type CustomData {
+  customApps: [CustomApp]
+}
+
+scalar CustomFields
+type CustomApp {
+  fields: CustomFields
+  id: String
+  major: Int
 }
 
 type OpenTextField {

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -35,12 +35,12 @@ type CurrencyFormatInfo {
 }
 
 type CustomData {
-  customApps: [CustomApp]
+  CustomApp: [CustomApp]
 }
 
-scalar CustomFields
+scalar CustomData
 type CustomApp {
-  fields: CustomFields
+  fields: CustomData
   id: String
   major: Int
 }


### PR DESCRIPTION
#### What problem is this solving?

Currently the context useOrderForm provides only a summary of data. The idea of this PR is to provide the possibility to access the custom data field directly from the context.
https://ibb.co/gvmxY6j

<!--- What is the motivation and context for this change? -->

Make it easy to access the "custom data" field directly in context.