### PR TITLE
Returns addresses with type search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Addresses with type `search` are not being filtered from the `selectedAddresses` anymore.
 
 ## [0.60.2] - 2021-06-10
 ### Fixed

--- a/node/package.json
+++ b/node/package.json
@@ -23,7 +23,7 @@
     "@types/lodash": "^4.14.138",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.41.0",
+    "@vtex/api": "6.42.1",
     "@vtex/test-tools": "^3.1.0",
     "@vtex/tsconfig": "^0.2.0",
     "typescript": "3.9.7",

--- a/node/utils/address.ts
+++ b/node/utils/address.ts
@@ -4,11 +4,10 @@ export function getSelectedDeliveryAddress(
   selectedAddresses: CheckoutAddress[]
 ) {
   return selectedAddresses.find((address: CheckoutAddress) => {
-    const isSearch = address.addressType === AddressType.SEARCH
     const isPickup = address.addressType === AddressType.PICKUP
     const isInStore = address.addressType === AddressType.INSTORE
 
-    return !isSearch && !isPickup && !isInStore
+    return !isPickup && !isInStore
   })
 }
 

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1597,10 +1597,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@6.41.0":
-  version "6.41.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.41.0.tgz#cee074ff49de8a5de92f3d353a4689275cb92f7b"
-  integrity sha512-RvfdpczsxCFacZkDSl2v2NmfD/bHFxHHn2xQsEwSQ+40snGxfOz56TlCbPbgMEtkC8Bf+1GGUkCIChRE6xnlLg==
+"@vtex/api@6.42.1":
+  version "6.42.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.42.1.tgz#b0030afa16750f995bf8296bdc8b22ce2fa5907b"
+  integrity sha512-b9U+G1ZuZ6MOsbiLn+/FEW/XnTIGnsKam1YxUf7OHJhPY+ebupkxIhFeAWub/Mf8xELaNl+0EdrwUbuq4dNFxQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1639,6 +1639,7 @@
     semver "^5.5.1"
     stats-lite vtex/node-stats-lite#dist
     tar-fs "^2.0.0"
+    tokenbucket "^0.3.2"
     uuid "^3.3.3"
     xss "^1.0.6"
 
@@ -2137,6 +2138,11 @@ bl@^3.0.0:
   integrity sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==
   dependencies:
     readable-stream "^3.0.1"
+
+bluebird@2.9.24:
+  version "2.9.24"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.24.tgz#14a2e75f0548323dc35aa440d92007ca154e967c"
+  integrity sha1-FKLnXwVIMj3DWqRA2SAHyhVOlnw=
 
 bluebird@^3.5.4:
   version "3.5.5"
@@ -5225,6 +5231,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redis@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-0.12.1.tgz#64df76ad0fc8acebaebd2a0645e8a48fac49185e"
+  integrity sha1-ZN92rQ/IrOuuvSoGReikj6xJGF4=
+
 regenerate-unicode-properties@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz#ef51e0f0ea4ad424b77bf7cb41f3e015c70a3f0e"
@@ -5698,7 +5709,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -5961,6 +5972,14 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+tokenbucket@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tokenbucket/-/tokenbucket-0.3.2.tgz#8172b2b58e3083acc8d914426fed15162a3a8e90"
+  integrity sha1-gXKytY4wg6zI2RRCb+0VFio6jpA=
+  dependencies:
+    bluebird "2.9.24"
+    redis "^0.12.1"
 
 tough-cookie@^2.3.3, tough-cookie@^2.3.4:
   version "2.5.0"


### PR DESCRIPTION
#### What problem is this solving?

The aim of this PR is to stop filtering addresses with type `search` from the list of `selectedAddresses`.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- [Run this query](https://jeff--vtexgame1.myvtex.com/_v/private/vtex.checkout-graphql@0.60.2/graphiql/v1?query=%7B%0A%20%20orderForm(orderFormId%3A%20%223ed93c387c9346f9ab8e7a0d95aedd8a%22)%20%7B%0A%20%20%20%20id%0A%20%20%20%20shipping%20%7B%0A%20%20%20%20%20%20selectedAddress%20%7B%0A%20%20%20%20%20%20%20%20addressId%0A%20%20%20%20%20%20%20%20addressType%0A%20%20%20%20%20%20%20%20city%0A%20%20%20%20%20%20%20%20complement%0A%20%20%20%20%20%20%20%20country%0A%20%20%20%20%20%20%20%20neighborhood%0A%20%20%20%20%20%20%20%20number%0A%20%20%20%20%20%20%20%20postalCode%0A%20%20%20%20%20%20%20%20receiverName%0A%20%20%20%20%20%20%20%20reference%0A%20%20%20%20%20%20%20%20state%0A%20%20%20%20%20%20%20%20street%0A%20%20%20%20%20%20%20%20isDisposable%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)
- Check that the `selectedAddress` is not `null` and have an address with type `search`

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
