### PR TITLE
Adding gclid to marketing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `gclid` to `marketingData`
 
 ## [0.61.3] - 2021-09-01
 ### Fixed

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -50,6 +50,7 @@ type MarketingData {
   utmiPart: String
   utmiPage: String
   coupon: String
+  gclid: String
   marketingTags: [String!]
 }
 
@@ -61,6 +62,7 @@ input MarketingDataInput {
   utmiPart: String
   utmiPage: String
   coupon: String
+  gclid: String
   marketingTags: [String!]
 }
 

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -21,6 +21,9 @@ export const resolvers = {
     coupon: (marketingData: OrderFormMarketingData) => {
       return marketingData.coupon ?? ''
     },
+    gclid: (marketingData: OrderFormMarketingData) => {
+      return marketingData.gclid ?? ''
+    },
     utmCampaign: (marketingData: OrderFormMarketingData) => {
       return marketingData.utmCampaign ?? ''
     },

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -24,6 +24,7 @@ declare global {
   }
 
   interface OrderFormMarketingData {
+    gclid?: string
     utmCampaign?: string
     utmMedium?: string
     utmSource?: string


### PR DESCRIPTION
#### What problem is this solving?

Currently, a store's revenue cannot be linked to a Google Adwords campaign because it missed the `gclid` when sending the orderPlaced data to GTM. This PR adds `gclid` to the marketing data so it can be used by GTM.

#### How should this be manually tested?

[Workspace](https://icaro--storecomponents.myvtex.com)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
