### PR TITLE
Add PR CI workflow (GH actions)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,48 @@
+name: PR actions
+'on':
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  danger-ci:
+    name: Danger CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: 12.x
+      - name: Danger CI
+        uses: vtex/danger@master
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+  linter:
+    name: Linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@master
+        with:
+          node-version: 12.x
+        env:
+          RUNNER_TEMP: /tmp
+      - name: yarn install
+        run: yarn install --frozen-lockfile
+      - name: Lint project
+        uses: vtex/action-lint@master
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@master
+        with:
+          node-version: 12.x
+        env:
+          RUNNER_TEMP: /tmp
+      - name: update submodules
+        run: git submodule update --init --recursive
+      - uses: vtex/action-io-app-test@master


### PR DESCRIPTION
#### What problem is this solving?

Adds linter, testing and "danger" to run on CI. Based on https://github.com/vtex-apps/place-components/blob/main/.github/workflows/pull-request.yml

#### How should this be manually tested?

Take a look at all checks on this PR 😬 . It should look like that:

![image](https://user-images.githubusercontent.com/26108090/136273454-dd6188d3-2f7e-4408-be56-4e6517a88d2c.png)

The only exception is that Linter will fail because there are many errors already :(

**#trivial**