### PR TITLE
Replace filter with a reduce logic for filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Ensure `itemIndex` property on `checkout-updateSubscriptionDataField` request
+
 ## [0.64.0] - 2021-11-23
 
 ## [0.63.1] - 2021-11-23

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -112,9 +112,15 @@ export const mutations = {
     const cleanItems = items.map(
       ({ options, index, uniqueId, ...rest }) => rest
     )
-    const withOptions = items.filter(
-      ({ options }) => !!options && options.length > 0
-    )
+
+    // Filter only the items with options and ensure that they have a proper index property
+    const withOptions = items.reduce((acc: OrderFormItemInput[], item: OrderFormItemInput, currentIndex: number) => {
+      if (item.options && item.options.length > 0) {
+        return [ ...acc, { ...item, index: item.index ?? currentIndex } ]
+      }
+
+      return acc
+    }, [])
 
     /**
      * Always be sure to make these requests in the same order you use


### PR DESCRIPTION
#### What problem is this solving?

The `updateSubscriptionDataField` requests with a body with itemIndex equals to null for `vtex.subscription.key.validity.duration.*` keys, what throws an error and does not properly update the `subscription` field on `orderForm`, preventing rate and benefits to be applied.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Breakpoints showing the error:
![withOptions mapping](https://user-images.githubusercontent.com/27451066/145126986-1f31ad4a-f841-4fb5-ad6e-9101f105c379.png)
![accessing nonexistent index prop ](https://user-images.githubusercontent.com/27451066/145127050-b6714c52-ddb4-4d1b-8866-5a2e2aafc54a.png)
![updateSubscriptionDataField with itemIndex equals to NaN](https://user-images.githubusercontent.com/27451066/145127246-d69a2a97-b4b5-4618-92e9-1b7457b1ec69.png)
![updateSubscriptionDataField with itemIndex equals to NaN](https://user-images.githubusercontent.com/27451066/145127268-7b4c0107-871e-4b2f-bc95-bb678d68c7e6.png)

[Workspace](https://brunomoreira--hsmuniversity.myvtex.com)

Throws an error 500
```bash
curl --location --request POST 'https://hsmuniversity.myvtex.com/_v/public/graphql/v1' \
--header 'Content-Type: application/json' \
--data-raw '{"query":"mutation addToCart($orderFormId: ID, $items: [ItemInput], $marketingData: MarketingDataInput, $salesChannel: String, $allowedOutdatedData: [String!]) {\n  addToCart(orderFormId: $orderFormId, items: $items, marketingData: $marketingData, salesChannel: $salesChannel, allowedOutdatedData: $allowedOutdatedData) @context(provider: \"vtex.checkout-graphql\") {\n      id\n      items {\n          attachments {\n              name\n              content\n          }\n      }\n  }\n}","variables":{"orderFormId":"74f90c7f34744439b78df59eabde1ac2","items":[{"id":2490,"quantity":1,"seller":1,"options":[{"assemblyId":"vtex.subscription.Assinatura","inputValues":{"vtex.subscription.key.frequency":"1 month","vtex.subscription.key.validity.duration.month":"8"}}]}],"marketingData":{},"allowedOutdatedData":["paymentData"]}}'
```

No error at all
```bash
curl --location --request POST 'https://brunomoreira--hsmuniversity.myvtex.com/_v/public/graphql/v1' \
--header 'Content-Type: application/json' \
--data-raw '{"query":"mutation addToCart($orderFormId: ID, $items: [ItemInput], $marketingData: MarketingDataInput, $salesChannel: String, $allowedOutdatedData: [String!]) {\n  addToCart(orderFormId: $orderFormId, items: $items, marketingData: $marketingData, salesChannel: $salesChannel, allowedOutdatedData: $allowedOutdatedData) @context(provider: \"vtex.checkout-graphql\") {\n      id\n      items {\n          attachments {\n              name\n              content\n          }\n      }\n  }\n}","variables":{"orderFormId":"74f90c7f34744439b78df59eabde1ac2","items":[{"id":2490,"quantity":1,"seller":1,"options":[{"assemblyId":"vtex.subscription.Assinatura","inputValues":{"vtex.subscription.key.frequency":"1 month","vtex.subscription.key.validity.duration.month":"8"}}]}],"marketingData":{},"allowedOutdatedData":["paymentData"]}}'
```

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ X ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
