### PR TITLE
Feature/add validity to subscription plan request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.64.1] - 2021-12-10
 
+### Added
+- Add support to key `vtex.subscription.key.validity.end` in assembly options for subscriptions
+
 ### Fixed
 - Ensure `itemIndex` property on `checkout-updateSubscriptionDataField` request
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "checkout-graphql",
   "vendor": "vtex",
-  "version": "0.64.1",
+  "version": "0.65.0-beta.0",
   "title": "Checkout GraphQL",
   "description": "Checkout GraphQL API",
   "builders": {

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -192,7 +192,7 @@ declare global {
       }
       type: string
       validity: {
-        end: string
+        end?: string
       }
     }
   }

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -191,7 +191,9 @@ declare global {
         periodicity: 'YEAR' | 'MONTH' | 'WEEK' | 'DAY'
       }
       type: string
-      validity: {}
+      validity: {
+        end: string
+      }
     }
   }
 

--- a/node/utils/subscriptions.ts
+++ b/node/utils/subscriptions.ts
@@ -4,6 +4,10 @@ const SUBSCRIPTION_PREFIX = `vtex.subscription`
 const SUBSCRIPTION_KEY_PREFIX = `${SUBSCRIPTION_PREFIX}.key`
 
 const SUBSCRIPTION_KEY_FREQUENCY = `${SUBSCRIPTION_KEY_PREFIX}.frequency`
+const SUBSCRIPTION_KEY_VALIDITY = `${SUBSCRIPTION_KEY_PREFIX}.validity`
+
+const SUBSCRIPTION_KEY_VALIDITY_END = `${SUBSCRIPTION_KEY_VALIDITY}.end`
+
 
 export function parseFrequency(frequency: string) {
   const match = frequency.trim().match(FREQUENCY_PATTERN)
@@ -20,6 +24,12 @@ export function parseFrequency(frequency: string) {
     interval: +count,
     periodicity: type.toUpperCase(),
   } as SubscriptionDataEntry['plan']['frequency']
+}
+
+export function parseValidity(validityEnd: string) {
+  return {
+    end: validityEnd,
+  }
 }
 
 export function generateSubscriptionDataEntry(
@@ -50,10 +60,16 @@ export function generateSubscriptionDataEntry(
       return null
     }
 
+    const validityEnd = subscriptionFrequencyOption.inputValues[SUBSCRIPTION_KEY_VALIDITY_END]
+
+    const planValidity = {
+      end: validityEnd
+    }
+    
     const subscriptionPlan = {
       frequency: planFrequency,
       type: planType,
-      validity: {},
+      validity: planValidity,
     }
 
     return {


### PR DESCRIPTION
#### What problem is this solving?
Currently, the `addToCart` resolver doesn't handle properly keys of subscriptions related to validity. This PR intends to add support to `vtex.subscription.key.validity.end` (that sets up the end date of a subscription).

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

1. Create a new orderForm (may use [this endpoint](https://hsmuniversity.vtexcommercestable.com.br/api/checkout/pub/orderForm/));
2. Get the orderFormId
3. Add an item with the proper assemblies using this [GraphiQL](https://brunomoreira--hsmuniversity.myvtex.com/_v/private/vtex.checkout-graphql@0.64.1/graphiql/v1?operationName=addToCart&query=mutation%20addToCart(%0A%20%20%24orderFormId%3A%20ID%0A%20%20%24items%3A%20%5BItemInput%5D%0A%20%20%24marketingData%3A%20MarketingDataInput%0A%20%20%24salesChannel%3A%20String%0A%20%20%24allowedOutdatedData%3A%20%5BString!%5D%0A)%20%7B%0A%20%20addToCart(%0A%20%20%20%20orderFormId%3A%20%24orderFormId%0A%20%20%20%20items%3A%20%24items%0A%20%20%20%20marketingData%3A%20%24marketingData%0A%20%20%20%20salesChannel%3A%20%24salesChannel%0A%20%20%20%20allowedOutdatedData%3A%20%24allowedOutdatedData%0A%20%20)%20%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D&variables=%7B%0A%20%20%20%20%22orderFormId%22%3A%20%22bd0a4ffe728347cf8f2b396edccf6afa%22%2C%0A%20%20%20%20%22items%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22id%22%3A%202503%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22quantity%22%3A%201%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22seller%22%3A%201%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22options%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22assemblyId%22%3A%20%22vtex.subscription.Assinatura%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22inputValues%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22vtex.subscription.key.frequency%22%3A%20%221%20month%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22vtex.subscription.key.validity.end%22%3A%20%222022-09-14%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%5D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%5D%2C%0A%20%20%20%20%22marketingData%22%3A%20%7B%7D%2C%0A%20%20%20%20%22allowedOutdatedData%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%22paymentData%22%0A%20%20%20%20%5D%0A%7D)
4. Check the `subscriptionData` filled in orderForm with data about validity;

Screenshots:

1. Empty `orderForm` start like this:
![image](https://user-images.githubusercontent.com/27451066/146086085-c1407ea5-cebb-44a6-b5aa-37d22deba590.png);
2. GraphQL request:
![image](https://user-images.githubusercontent.com/27451066/146086227-e835ae2f-bb83-4f74-b441-98cbf0d29ac0.png)
3. Subscription Data filled with `validity.end`:
![image](https://user-images.githubusercontent.com/27451066/146086377-15e8b19f-b41c-4065-aa66-842c419cef51.png)

If you do the same using current version, `validity.end` will be always equals to null. Like this:
![image](https://user-images.githubusercontent.com/27451066/146086585-b503e050-86ef-4f49-8ab2-0a1752d0aadb.png)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
