### PR TITLE
Feature/add custom data field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `customData` field on OrderForm.graphql and `customData` types
+
 ## [0.64.3] - 2022-01-10
 ### Changed
 - Reduced min replicas

--- a/graphql/types/OrderForm.graphql
+++ b/graphql/types/OrderForm.graphql
@@ -16,6 +16,19 @@ type OrderForm {
   allowManualPrice: Boolean
   openTextField: OpenTextField
   storePreferencesData: StorePreferencesData
+  customData: CustomData
+}
+
+type CustomData {
+  customApps: [CustomApp!]!
+}
+
+scalar CustomFieldsObject
+
+type CustomApp {
+  id: ID!
+  major: Int!
+  fields: CustomFieldsObject!
 }
 
 type StorePreferencesData {


### PR DESCRIPTION
#### What problem is this solving?

Having the `customData` field on the schema will allow this information to be fetched when using the query, helping the development of apps which could use this data defined on the order form context during navigation on IO stores.

#### How should this be manually tested?

[Workspace](https://gabiru--sandboxbrdev.myvtex.com/_v/private/vtex.checkout-graphql@0.64.3/graphiql/v1?query=query%20%7B%0A%20%20orderForm(orderFormId%3A%20%227976f9e014c94592950569217f51b0b9%22)%20%7B%0A%20%20%20%20id%0A%20%20%20%20customData%20%7B%0A%20%20%20%20%20%20customApps%20%7B%0A%20%20%20%20%20%20%20%20fields%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20major%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Another PR will be opened on the [vtex.checkout-resources](https://github.com/vtex-apps/checkout-resources), which contains the query used by [vtex.order-manager](https://github.com/vtex-apps/order-manager) to populate the order form context.