### PR TITLE
Update priceTags.value to Float type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update type for `priceTags.value` from `Int` to `Float`.
 
 ## [0.65.0] - 2022-01-17
 

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -181,7 +181,7 @@ type PriceTag {
   name: String
   ratesAndBenefitsIdentifier: RatesAndBenefitsIdentifier
   rawValue: Float
-  value: Int
+  value: Float
 }
 
 type RatesAndBenefitsIdentifier {


### PR DESCRIPTION
#### What problem is this solving?

Fix an error when the value for the `priceTags.value` exceeds the maximum for GraphQL's `Int` data type.

#### How should this be manually tested?

You can see the error [using this cartlink](https://sbdsefprod.myvtex.com/checkout/cart/add/?sku=9207&qty=300&seller=1&sc=1&sku=9204&qty=50&seller=1&sc=1&sku=9206&qty=50&seller=1&sc=1&sku=9230&qty=1&seller=1&sc=1), go back to the home page and search the network for the orderForm query (it should have an error).

Using [this workspace](https://chk--sbdsefprod.myvtex.com/checkout/cart/add/?sku=9207&qty=300&seller=1&sc=1&sku=9204&qty=50&seller=1&sc=1&sku=9206&qty=50&seller=1&sc=1&sku=9230&qty=1&seller=1&sc=1) you can see the issue has been fixed.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

This PR was created to solve [this escalation](https://vtex.slack.com/archives/C017NPK8U86/p1642615598212500).