### PR TITLE
Added SLA type in deliveryOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `DeliveryOptions.sla` props in graphql schema
+
 ## [0.65.2] - 2022-03-22
 
 ### Added

--- a/graphql/types/Shipping.graphql
+++ b/graphql/types/Shipping.graphql
@@ -13,6 +13,7 @@ type DeliveryOption {
   price: Int!
   estimate: String!
   isSelected: Boolean!
+  sla: SLA
 }
 
 type PickupOption {
@@ -84,4 +85,43 @@ enum AddressType {
   giftRegistry
   pickup
   search
+}
+
+type deliveryChannels {
+  id: String
+}
+
+type SLA {
+  deliveryChannel: String
+  deliveryIds: [DeliveryIds]
+  deliveryWindow: String!
+  id: String
+  listPrice: Float
+  lockTTL: String!
+  name: String
+  pickupDistance: Int
+  pickupPointId: String!
+  pickupStoreInfo: PickupStoreInfo
+  polygonName: String
+  price: Float
+  shippingEstimate: String
+  shippingEstimateDate: String!
+  tax: Float
+  transitTime: String
+}
+
+type DeliveryIds {
+  courierId: String
+  courierName: String
+  dockId: String
+  quantity: Int
+  warehouseId: String
+}
+
+type PickupStoreInfo {
+  isPickupStore: Boolean 
+  friendlyName: String! 
+  address: String! 
+  additionalInfo: String! 
+  dockId: String!
 }


### PR DESCRIPTION
#### What problem is this solving?

DeliveryOption hasn't SLA data where we can get warehouse ID for example and other info.


#### Type of changes

_ | New feature <!-- a non-breaking change which adds functionality -->


<img width="811" alt="image" src="https://user-images.githubusercontent.com/33559104/172335426-5d439be8-1590-4d08-a832-62c3bba3b74c.png">
