### PR TITLE
Adds sampling on authorizationMetrics logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- `withAuthMetrics` directive now logs 1 from 100 unauthorized requests
+- `withAuthMetrics` directive now logs 1% of unauthorized requests
 
 ## [0.65.2] - 2022-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `withAuthMetrics` directive now logs 1 from 100 unauthorized requests
 
 ## [0.65.2] - 2022-03-22
 

--- a/node/directives/authorization.ts
+++ b/node/directives/authorization.ts
@@ -20,7 +20,7 @@ function checkForAuthorization(ctx: any, info: GraphQLResolveInfo) {
   const vtexIdToken =
     ctx.cookies.get('VtexIdclientAutCookie') ?? ctx.get('VtexIdclientAutCookie')
 
-  if (!vtexIdToken) {
+  if (!vtexIdToken && Math.floor(Math.random() * 100) == 0) {
     logger.warn({
       message: 'Private route being accessed by unauthorized user',
       userAgent,

--- a/node/directives/authorization.ts
+++ b/node/directives/authorization.ts
@@ -20,7 +20,7 @@ function checkForAuthorization(ctx: any, info: GraphQLResolveInfo) {
   const vtexIdToken =
     ctx.cookies.get('VtexIdclientAutCookie') ?? ctx.get('VtexIdclientAutCookie')
 
-  if (!vtexIdToken && Math.floor(Math.random() * 100) == 0) {
+  if (!vtexIdToken && Math.floor(Math.random() * 100) === 0) {
     logger.warn({
       message: 'Private route being accessed by unauthorized user',
       userAgent,


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR adds sampling to the `authorizationMetrics` directive logs.

#### What problem is this solving?
We found that logs with the message `Private route being accessed by unauthorized user` are responsible for sending **3GB of data to Splunk by hour**.

So, this PR adds a random function to reduce the amount 100x, decreasing the amount logged to 30MB per hour.

#### How should this be manually tested?
Nothing should have changed, and the amount logged should decrease

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️| Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
