### PR TITLE
[CHK-2128] Properly handle the new CheckoutOrderFormOwnership cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Handle the new `CheckoutOrderFormOwnership` cookie.
 
 ## [0.65.6] - 2022-09-22
 

--- a/graphql/directives.graphql
+++ b/graphql/directives.graphql
@@ -2,6 +2,8 @@ directive @withSegment on FIELD_DEFINITION
 
 directive @withOrderFormId on FIELD_DEFINITION
 
+directive @withOwnerId on FIELD_DEFINITION
+
 directive @noCache on FIELD_DEFINITION
 
 directive @withAuthMetrics on FIELD_DEFINITION

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -4,6 +4,7 @@ type Query {
     @noCache
     @withAuthMetrics
     @withOrderFormId
+    @withOwnerId
     @withSegment
   checkoutProfile(email: String!): CheckoutProfile @withAuthMetrics @noCache
   shippingSLA(
@@ -15,6 +16,7 @@ type Query {
     @withAuthMetrics
     @withSegment
     @withOrderFormId
+    @withOwnerId
 }
 
 type Mutation {
@@ -24,52 +26,57 @@ type Mutation {
     marketingData: MarketingDataInput
     salesChannel: String
     allowedOutdatedData: [String!]
-  ): OrderForm! @withAuthMetrics @withOrderFormId @withSegment @noCache
+  ): OrderForm! @withAuthMetrics @withOrderFormId @withOwnerId @withSegment @noCache
 
   updateItems(
     orderFormId: ID
     orderItems: [ItemInput]
     splitItem: Boolean = true
     allowedOutdatedData: [String!]
-  ): OrderForm! @withAuthMetrics @withOrderFormId @noCache
+  ): OrderForm! @withAuthMetrics @withOrderFormId @withOwnerId @noCache
 
   addItemOffering(orderFormId: ID, offeringInput: OfferingInput): OrderForm!
     @withAuthMetrics
     @withOrderFormId
+    @withOwnerId
     @noCache
   removeItemOffering(orderFormId: ID, offeringInput: OfferingInput): OrderForm!
     @withAuthMetrics
     @withOrderFormId
+    @withOwnerId
     @noCache
 
   addBundleItemAttachment(
     orderFormId: ID
     bundleItemAttachmentInput: BundleItemAttachmentInput
-  ): OrderForm! @withAuthMetrics @withOrderFormId @noCache
+  ): OrderForm! @withAuthMetrics @withOrderFormId @withOwnerId @noCache
   removeBundleItemAttachment(
     orderFormId: ID
     bundleItemAttachmentInput: BundleItemAttachmentInput
-  ): OrderForm! @withAuthMetrics @withOrderFormId @noCache
+  ): OrderForm! @withAuthMetrics @withOrderFormId @withOwnerId @noCache
 
   insertCoupon(orderFormId: ID, text: String): OrderForm!
     @withOrderFormId
+    @withOwnerId
     @noCache
 
   estimateShipping(orderFormId: ID, address: AddressInput): OrderForm!
     @withAuthMetrics
     @withOrderFormId
+    @withOwnerId
     @noCache
 
   selectDeliveryOption(orderFormId: ID, deliveryOptionId: String): OrderForm!
     @withAuthMetrics
     @withOrderFormId
+    @withOwnerId
     @noCache
 
   selectPickupOption(
     orderFormId: ID
     pickupOptionId: String
     itemId: String
-  ): OrderForm! @withAuthMetrics @withOrderFormId @noCache
+  ): OrderForm! @withAuthMetrics @withOrderFormId @withOwnerId @noCache
 
   """
   Changes the currently selected address in the shipping data
@@ -78,51 +85,57 @@ type Mutation {
   updateSelectedAddress(orderFormId: ID, input: AddressInput!): OrderForm!
     @withAuthMetrics
     @withOrderFormId
+    @withOwnerId
     @noCache
 
   savePaymentToken(
     orderFormId: ID
     paymentTokens: [PaymentToken]
-  ): SavePaymentTokenPayload @withAuthMetrics @withOrderFormId @noCache
+  ): SavePaymentTokenPayload @withAuthMetrics @withOrderFormId @withOwnerId @noCache
 
   updateOrderFormProfile(orderFormId: ID, input: UserProfileInput!): OrderForm!
     @withAuthMetrics
     @withOrderFormId
+    @withOwnerId
     @noCache
 
   updateClientPreferencesData(
     orderFormId: ID
     input: ClientPreferencesDataInput!
-  ): OrderForm! @withAuthMetrics @withOrderFormId @noCache
+  ): OrderForm! @withAuthMetrics @withOrderFormId @withOwnerId @noCache
 
   updateOrderFormPayment(orderFormId: ID, input: PaymentDataInput!): OrderForm!
     @withAuthMetrics
     @withOrderFormId
+    @withOwnerId
     @noCache
 
   setManualPrice(orderFormId: ID, input: ManualPriceInput!): OrderForm!
     @withAuthMetrics
     @withOrderFormId
+    @withOwnerId
     @noCache
 
   updateItemsOrdination(
     orderFormId: ID
     ascending: Boolean!
     criteria: ItemsOrdinationCriteria!
-  ): OrderForm! @withAuthMetrics @withOrderFormId @noCache
+  ): OrderForm! @withAuthMetrics @withOrderFormId @withOwnerId @noCache
 
   clearOrderFormMessages(orderFormId: ID): OrderForm!
     @withAuthMetrics
     @withOrderFormId
+    @withOwnerId
     @noCache
 
   updateOrderFormOpenTextField(
     orderFormId: ID
     input: OrderFormOpenTextInput!
-  ): OrderForm! @withAuthMetrics @withOrderFormId @noCache
+  ): OrderForm! @withAuthMetrics @withOrderFormId @withOwnerId @noCache
 
   updateOrderFormMarketingData(input: MarketingDataInput!): OrderForm!
     @withAuthMetrics
     @withOrderFormId
+    @withOwnerId
     @noCache
 }

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -128,8 +128,8 @@ export class Checkout extends JanusClient {
       fields,
       { metric: 'checkout-updateOrderFormProfile' }
     )
-    forwardCheckoutCookies(headers, ctx, [OWNERSHIP_COOKIE]);
-    return data;
+    forwardCheckoutCookies(headers, ctx, [OWNERSHIP_COOKIE])
+    return data
   }
 
   public updateOrderFormShipping = (orderFormId: string, shipping: any) =>

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -6,6 +6,8 @@ import {
   RequestConfig,
 } from '@vtex/api'
 import { UserProfileInput } from 'vtex.checkout-graphql'
+import { OWNERSHIP_COOKIE } from '../constants'
+import { forwardCheckoutCookies } from '../resolvers/orderForm'
 
 import { checkoutCookieFormat, statusToError } from '../utils'
 
@@ -116,15 +118,19 @@ export class Checkout extends JanusClient {
       { metric: 'checkout-updateOrderFormPayment' }
     )
 
-  public updateOrderFormProfile = (
+  public updateOrderFormProfile = async (
     orderFormId: string,
-    fields: UserProfileInput
-  ) =>
-    this.post<CheckoutOrderForm>(
+    fields: UserProfileInput,
+    ctx: Context,
+  ) => {
+    const { data, headers } = await this.postRaw<CheckoutOrderForm>(
       this.routes.attachmentsData(orderFormId, 'clientProfileData'),
       fields,
       { metric: 'checkout-updateOrderFormProfile' }
     )
+    forwardCheckoutCookies(headers, ctx, [OWNERSHIP_COOKIE]);
+    return data;
+  }
 
   public updateOrderFormShipping = (orderFormId: string, shipping: any) =>
     this.post<CheckoutOrderForm>(

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -9,7 +9,7 @@ import { UserProfileInput } from 'vtex.checkout-graphql'
 import { OWNERSHIP_COOKIE } from '../constants'
 import { forwardCheckoutCookies } from '../resolvers/orderForm'
 
-import { checkoutCookieFormat, statusToError } from '../utils'
+import { checkoutCookieFormat, ownershipCookieFormat, statusToError } from '../utils'
 
 export interface SimulationData {
   country: string
@@ -401,10 +401,11 @@ export class Checkout extends JanusClient {
   }
 
   private getCommonHeaders = () => {
-    const { orderFormId } = (this.context as unknown) as CustomIOContext
+    const { orderFormId, ownerId } = (this.context as unknown) as CustomIOContext
     const checkoutCookie = orderFormId ? checkoutCookieFormat(orderFormId) : ''
+    const ownershipCookie = ownerId ? ownershipCookieFormat(ownerId) : ''
     return {
-      Cookie: `${checkoutCookie}vtex_segment=${this.context.segmentToken};vtex_session=${this.context.sessionToken};`,
+      Cookie: `${checkoutCookie}${ownershipCookie}vtex_segment=${this.context.segmentToken};vtex_session=${this.context.sessionToken};`,
     }
   }
 
@@ -486,6 +487,6 @@ export class Checkout extends JanusClient {
 
 export class CheckoutNoCookies extends Checkout {
   constructor(ctx: IOContext, options?: InstanceOptions) {
-    super({ ...ctx, orderFormId: null } as any, { ...options, headers: {} })
+    super({ ...ctx, orderFormId: null, ownerId: null } as any, { ...options, headers: {} })
   }
 }

--- a/node/constants/index.ts
+++ b/node/constants/index.ts
@@ -7,6 +7,11 @@ export enum AddressType {
   SEARCH = 'search',
 }
 
+// Cookies
+export const CHECKOUT_COOKIE = 'checkout.vtex.com'
+export const ASPXAUTH_COOKIE = '.ASPXAUTH'
+export const OWNERSHIP_COOKIE = 'CheckoutOrderFormOwnership'
+
 // Delivery channels
 export const DELIVERY = 'delivery'
 export const PICKUP_IN_POINT = 'pickup-in-point'

--- a/node/directives/index.ts
+++ b/node/directives/index.ts
@@ -2,10 +2,12 @@ import { AuthorizationMetrics } from './authorization'
 import { WithSegment } from './withSegment'
 import { WithOrderFormId } from './withOrderFormId'
 import { NoCache } from './noCache'
+import { WithOwnerId } from './withOwnerId'
 
 export const schemaDirectives = {
   withAuthMetrics: AuthorizationMetrics,
   withSegment: WithSegment,
   withOrderFormId: WithOrderFormId,
+  withOwnerId: WithOwnerId,
   noCache: NoCache,
 }

--- a/node/directives/withOwnerId.ts
+++ b/node/directives/withOwnerId.ts
@@ -1,0 +1,15 @@
+import { defaultFieldResolver, GraphQLField } from 'graphql'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+
+import { getOwnerIdFromCookie } from '../utils'
+
+export class WithOwnerId extends SchemaDirectiveVisitor {
+  public visitFieldDefinition(field: GraphQLField<any, any>) {
+    const { resolve = defaultFieldResolver } = field
+    field.resolve = async (root: any, args: any, ctx: Context, info: any) => {
+      const checkoutOwnerId = getOwnerIdFromCookie(ctx.cookies)
+      ctx.vtex.ownerId = checkoutOwnerId
+      return resolve(root, args, ctx, info)
+    }
+  }
+}

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -204,7 +204,7 @@ export async function forwardCheckoutCookies(
   const responseSetCookies: string[] = rawHeaders?.['set-cookie'] || []
 
   const host = ctx.get('x-forwarded-host')
-  const forwardedSetCookies = filterAllowedCookies(responseSetCookies, allowList);
+  const forwardedSetCookies = filterAllowedCookies(responseSetCookies, allowList)
   const parseAndClean = compose(parseCookie, replaceDomain(host))
   const cleanCookies = forwardedSetCookies.map(parseAndClean)
   cleanCookies.forEach(({ name, value, options }) => {

--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -1,7 +1,7 @@
 import { prop, propOr, compose } from 'ramda'
 import { QueryOrderFormArgs } from 'vtex.checkout-graphql'
 
-import { CHECKOUT_COOKIE, parseCookie } from '../utils'
+import { parseCookie } from '../utils'
 import { fillMessages } from './messages'
 import { getShippingInfo } from '../utils/shipping'
 import {
@@ -9,7 +9,7 @@ import {
   isProfileValid,
   isPaymentValid,
 } from '../utils/validation'
-import { VTEX_SESSION } from '../constants'
+import { ASPXAUTH_COOKIE, CHECKOUT_COOKIE, OWNERSHIP_COOKIE, VTEX_SESSION } from '../constants'
 import { OrderFormIdArgs } from '../utils/args'
 
 interface StoreSettings {
@@ -21,11 +21,13 @@ interface StoreSettings {
   enableCriticalCSS: boolean
 }
 
-const SetCookieWhitelist = [CHECKOUT_COOKIE, '.ASPXAUTH']
+const ALL_SET_COOKIES = [CHECKOUT_COOKIE, ASPXAUTH_COOKIE, OWNERSHIP_COOKIE]
 
-const isWhitelistedSetCookie = (cookie: string) => {
-  const [key] = cookie.split('=')
-  return SetCookieWhitelist.includes(key)
+const filterAllowedCookies = (setCookies: string[], allowList: string[]) => {
+  return setCookies.filter(setCookie => {
+    const [key] = setCookie.split('=')
+    return allowList.includes(key)
+  })
 }
 
 const replaceDomain = (host: string) => (cookie: string) =>
@@ -196,12 +198,13 @@ export async function syncWithStoreLocale(
 
 export async function forwardCheckoutCookies(
   rawHeaders: Record<string, any>,
-  ctx: Context
+  ctx: Context,
+  allowList: string[] = ALL_SET_COOKIES
 ) {
   const responseSetCookies: string[] = rawHeaders?.['set-cookie'] || []
 
   const host = ctx.get('x-forwarded-host')
-  const forwardedSetCookies = responseSetCookies.filter(isWhitelistedSetCookie)
+  const forwardedSetCookies = filterAllowedCookies(responseSetCookies, allowList);
   const parseAndClean = compose(parseCookie, replaceDomain(host))
   const cleanCookies = forwardedSetCookies.map(parseAndClean)
   cleanCookies.forEach(({ name, value, options }) => {
@@ -299,7 +302,8 @@ export const mutations = {
 
     const orderFormWithProfile = await checkout.updateOrderFormProfile(
       orderFormId!,
-      input
+      input,
+      ctx,
     )
 
     return orderFormWithProfile

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -21,6 +21,7 @@ declare global {
   interface CustomIOContext extends IOContext {
     segment?: SegmentData
     orderFormId?: string
+    ownerId?: string
   }
 
   interface OrderFormMarketingData {

--- a/node/utils/index.ts
+++ b/node/utils/index.ts
@@ -2,6 +2,7 @@ import { AuthenticationError, ForbiddenError, UserInputError } from '@vtex/api'
 import { AxiosError } from 'axios'
 import { parse } from 'set-cookie-parser'
 import { SetOption } from 'cookies'
+import { CHECKOUT_COOKIE } from '../constants'
 
 export function generateRandomName() {
   return (1 + Math.random()).toString(36).substring(2)
@@ -55,9 +56,6 @@ export const parseCookie = (cookie: string): ParsedCookie => {
     options: extraOptions,
   }
 }
-
-/** Checkout cookie methods */
-export const CHECKOUT_COOKIE = 'checkout.vtex.com'
 
 export function checkoutCookieFormat(orderFormId: string) {
   return `${CHECKOUT_COOKIE}=__ofid=${orderFormId};`

--- a/node/utils/index.ts
+++ b/node/utils/index.ts
@@ -2,7 +2,7 @@ import { AuthenticationError, ForbiddenError, UserInputError } from '@vtex/api'
 import { AxiosError } from 'axios'
 import { parse } from 'set-cookie-parser'
 import { SetOption } from 'cookies'
-import { CHECKOUT_COOKIE } from '../constants'
+import { CHECKOUT_COOKIE, OWNERSHIP_COOKIE } from '../constants'
 
 export function generateRandomName() {
   return (1 + Math.random()).toString(36).substring(2)
@@ -61,9 +61,17 @@ export function checkoutCookieFormat(orderFormId: string) {
   return `${CHECKOUT_COOKIE}=__ofid=${orderFormId};`
 }
 
+export function ownershipCookieFormat(ownerId: string) {
+  return `${OWNERSHIP_COOKIE}=${ownerId};`
+}
+
 export function getOrderFormIdFromCookie(cookies: Context['cookies']) {
   const cookie = cookies.get(CHECKOUT_COOKIE)
   return cookie?.split('=')[1]
+}
+
+export function getOwnerIdFromCookie(cookies: Context['cookies']) {
+  return cookies.get(OWNERSHIP_COOKIE)
 }
 
 interface ParsedCookie {


### PR DESCRIPTION
[Jira Issue](https://vtex-dev.atlassian.net/browse/CHK-2128)

#### What problem is this solving?
Handle the new CheckoutOrderFormOwnership cookie, forwarding when necessary.

#### How should this be manually tested?

The cookie comes back in set-cookie when included in the API requests:
```
$ curl -v 'https://brunoh--qastore.myvtex.com/_v/private/graphql/v1?domain=store' \
  -H 'content-type: application/json' \
  -H 'cookie: checkout.vtex.com=__ofid=bec5432879934595babe0d4efe39beac; CheckoutOrderFormOwnership=2d048a247bdf461fb298bfff177ec665; vtex-commerce-env=beta' \
  --data-raw '{"operationName":"orderForm","variables":{},"extensions":{"persistedQuery":{"version":1,"sha256Hash":"95073518e37243112b2f2128fb1dced29731fcbf2f32df6cf9923c07fe0d82f2","sender":"vtex.checkout-resources@0.x","provider":"vtex.checkout-graphql@0.x"},"variables":"eyJyZWZyZXNoT3V0ZGF0ZWREYXRhIjpmYWxzZX0="}}' \
  2>&1 | grep -Fi set-cookie:
        
< set-cookie: checkout.vtex.com=__ofid=bec5432879934595babe0d4efe39beac; path=/; expires=Tue, 25 Apr 2023 19:12:27 GMT; domain=brunoh--qastore.myvtex.com; samesite=lax; secure; httponly
< set-cookie: CheckoutOrderFormOwnership=2d048a247bdf461fb298bfff177ec665; path=/; expires=Tue, 25 Apr 2023 19:12:27 GMT; domain=brunoh--qastore.myvtex.com; samesite=strict; secure; httponly
```

The set-cookie is included when updating the clientProfileAttachment (which generates an `ownerId`):
```
curl -v 'https://brunoh--qastore.myvtex.com/_v/private/graphql/v1?domain=store' \
  -H 'content-type: application/json' \
  -H 'cookie: checkout.vtex.com=__ofid=bec5432879934595babe0d4efe39beac; vtex-commerce-env=beta' \
  --data-raw '{"query":"mutation {updateOrderFormProfile (orderFormId:\"bec5432879934595babe0d4efe39beac\", input: {email: \"newshopper_100@mailinator.com\"}) @context(provider: \"vtex.checkout-graphql@0.x\") { userProfileId }}"}' \
  2>&1 | grep -Fi set-cookie:

< set-cookie: CheckoutOrderFormOwnership=70ea73761d63443cbc1b3fae8684e61b; path=/; expires=Tue, 25 Apr 2023 19:33:24 GMT; domain=brunoh--qastore.myvtex.com; samesite=strict; secure; httponly
```
PS: In this case the set-cookie will just appear the first time a "new" profile attachment is sent (new email).
Example:
call one time with "newshopper_100@mailinator.com" => receive set-cookie
call another time with "newshopper_100@mailinator.com" => no set-cookie
call another time with "newshopper_101@mailinator.com" => receive set-cookie

This behavior is not related to this PR, it is just how it was implemented in the Checkout API.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
