### PR TITLE
Make the maximum quantity for an item available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `availableQuantity` to type `Item` to return the maximum available quantity.
+
 ## [0.66.0] - 2022-11-03
 ### Added
 - Handle the new `CheckoutOrderFormOwnership` cookie.

--- a/graphql/types/Item.graphql
+++ b/graphql/types/Item.graphql
@@ -10,6 +10,10 @@ type Item {
   additionalInfo: ItemAdditionalInfo
   assemblyOptions: AssemblyOptionItem
   availability: String
+  """
+  Max available quantity.
+  """
+  availableQuantity: Float
   attachmentOfferings: [AttachmentOffering!]!
   attachments: [Attachment!]!
   bundleItems: [Item!]!

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "checkout-graphql",
   "vendor": "vtex",
-  "version": "0.66.0",
+  "version": "0.67.0-beta.0",
   "title": "Checkout GraphQL",
   "description": "Checkout GraphQL API",
   "builders": {
@@ -15,9 +15,7 @@
   },
   "credentialType": "absolute",
   "mustUpdateAt": "2019-11-05",
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [
     {
       "name": "vtex.messages:translate-messages"

--- a/node/clients/searchGraphQL/productQuery.ts
+++ b/node/clients/searchGraphQL/productQuery.ts
@@ -1,3 +1,12 @@
+interface Offer {
+  AvailableQuantity: number
+}
+
+interface Seller {
+  sellerDefault: boolean
+  commertialOffer: Offer
+}
+
 export interface ProductResponse {
   productName: string
   productId: string
@@ -8,6 +17,7 @@ export interface ProductResponse {
       name: string
       values: string[]
     }>
+    sellers: Seller[]
   }>
 }
 
@@ -30,6 +40,12 @@ query Product($values: [ID!]!) {
       variations {
         name
         values
+      }
+      sellers {
+        sellerDefault
+        commertialOffer {
+          AvailableQuantity
+        }
       }
     }
   }

--- a/node/resolvers/items.ts
+++ b/node/resolvers/items.ts
@@ -79,6 +79,22 @@ export const root = {
 
       return getVariations(item.id, product?.items ?? [])
     },
+    availableQuantity: async (
+      item: OrderFormItem,
+      _: unknown,
+      ctx: Context
+    ) => {
+      const {
+        vtex: { logger },
+        clients: { searchGraphQL },
+      } = ctx
+
+      const product = await getProductInfo(item, searchGraphQL, logger)
+      const sku = product?.items.find(({ itemId }) => itemId === item.id)
+
+      return sku?.sellers?.find(({ sellerDefault }) => sellerDefault)
+        ?.commertialOffer?.AvailableQuantity
+    },
   },
 }
 

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -469,6 +469,7 @@ declare global {
       offeringTypeId: any | null
     }
     availability: string
+    availableQuantity?: number
     detailUrl: string
     id: string
     imageUrls?: {


### PR DESCRIPTION
#### What problem is this solving?

In https://github.com/vtex-apps/product-list/pull/144 we are trying to fix the [Known Issue 659909 (Quantity selector component doesn't return to the limit value when user quickly clicks)](https://vtexhelp.zendesk.com/agent/tickets/659909) and we can do it if we have the checkout items return their maximum quantity.

#### How should this be manually tested?

Before|After
-|-
![Before](https://user-images.githubusercontent.com/381395/213585868-52ed72a6-9ea1-4838-a1c5-18531fa6b108.gif)|![After](https://user-images.githubusercontent.com/381395/213585877-aa1ff4eb-002e-458c-800e-6e9f5b611eab.gif)

On this PDP, the max availability for the product is 3. Add the product to the cart, and, in the mini cart, you shouldn't be able to increase its quantity past 3, even if you click quickly.

[Workspace](https://ki564283filipelima--lojadokadu.myvtex.com/livro/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

- https://github.com/vtex-apps/product-list/pull/144 where the field is going to be used.
- https://github.com/vtex-apps/checkout-resources/pull/99 where the field is going to be queried.

<!-- Put any relevant information that doesn't fit in the other sections here. -->
