### PR TITLE
Add validation for messages length to avoid unnecessary call

### DIFF
--- a/node/resolvers/orderForm.ts
+++ b/node/resolvers/orderForm.ts
@@ -9,7 +9,12 @@ import {
   isProfileValid,
   isPaymentValid,
 } from '../utils/validation'
-import { ASPXAUTH_COOKIE, CHECKOUT_COOKIE, OWNERSHIP_COOKIE, VTEX_SESSION } from '../constants'
+import {
+  ASPXAUTH_COOKIE,
+  CHECKOUT_COOKIE,
+  OWNERSHIP_COOKIE,
+  VTEX_SESSION,
+} from '../constants'
 import { OrderFormIdArgs } from '../utils/args'
 
 interface StoreSettings {
@@ -101,7 +106,7 @@ export const root = {
 
       const newMessages = fillMessages(orderForm.messages)
 
-      if (orderForm.messages) {
+      if (orderForm.messages && orderForm.messages.length > 0) {
         checkout.clearMessages(orderForm.orderFormId)
       }
 
@@ -204,7 +209,10 @@ export async function forwardCheckoutCookies(
   const responseSetCookies: string[] = rawHeaders?.['set-cookie'] || []
 
   const host = ctx.get('x-forwarded-host')
-  const forwardedSetCookies = filterAllowedCookies(responseSetCookies, allowList)
+  const forwardedSetCookies = filterAllowedCookies(
+    responseSetCookies,
+    allowList
+  )
   const parseAndClean = compose(parseCookie, replaceDomain(host))
   const cleanCookies = forwardedSetCookies.map(parseAndClean)
   cleanCookies.forEach(({ name, value, options }) => {
@@ -222,10 +230,7 @@ export const queries = {
     args: QueryOrderFormArgs,
     ctx: Context
   ): Promise<CheckoutOrderForm> => {
-    const {
-      clients,
-      vtex,
-    } = ctx
+    const { clients, vtex } = ctx
     const { orderFormId = vtex.orderFormId, refreshOutdatedData } = args
 
     let { data: newOrderForm, headers } = await clients.checkout.orderFormRaw(
@@ -303,7 +308,7 @@ export const mutations = {
     const orderFormWithProfile = await checkout.updateOrderFormProfile(
       orderFormId!,
       input,
-      ctx,
+      ctx
     )
 
     return orderFormWithProfile


### PR DESCRIPTION
#### What problem is this solving?
Hoje chamamos a API do checkout no endpoint de messages/clear para limpar as mensagens mesmo que não haja nenhuma. Isso ocorre porque a validação é feita somente em cima da existência do objeto mensagens e não se ele possui algum item dentro do array de fato.

Esse PR está sendo criado para fazer essa validação e reduzir a quantidade de chamadas desnecessárias a API.

#### How should this be manually tested?

[Workspace](https://testmessages--hmcolombia.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
