### PR TITLE
patch: send log to OS if no rcSessionIdv7 cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Send log to OpenSearch if no `RCSessionIdv7` cookie is found.
+
 ## [0.67.0] - 2024-02-27
 
 ### Added

--- a/node/directives/authorization.ts
+++ b/node/directives/authorization.ts
@@ -37,6 +37,21 @@ function checkForAuthorization(ctx: any, info: GraphQLResolveInfo) {
       queryReturnType: info?.returnType.toString(),
     })
   }
+
+  const vtexRCSessionIdv7 =
+    ctx.cookies.get('VtexRCSessionIdv7') ?? ctx.get('VtexRCSessionIdv7')
+
+  if (!vtexRCSessionIdv7) {
+    logger.warn({
+      message: 'No RCSessionIdv7 cookie found',
+      userAgent,
+      forwardedFor,
+      forwardedHost,
+      forwardedPath,
+      origin,
+      vtexCaller,
+    })
+  }
 }
 
 export class AuthorizationMetrics extends SchemaDirectiveVisitor {

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
     "@types/set-cookie-parser": "^2.4.2",
-    "@vtex/api": "6.45.20",
+    "@vtex/api": "6.46.1",
     "@vtex/test-tools": "^3.1.0",
     "@vtex/tsconfig": "^0.2.0",
     "typescript": "3.9.7",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1604,10 +1604,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@6.45.20":
-  version "6.45.20"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.20.tgz#c1090249a424fd700499de3fed0d80d99ff53332"
-  integrity sha512-O7RJWWr4PfvixNpc0GgQh85iKcv9j1IKkpApwJQSW/WzxoTgSrcjYHOVUmJ1GWWBmRV/qvB2VaV6Ow1QL3UOCQ==
+"@vtex/api@6.46.1":
+  version "6.46.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.1.tgz#55a8755ae48f5400e7f1ed1921cd547950bb7a2a"
+  integrity sha512-geoxVvyWoQpOQ70Zmx3M8SBkRoGOS/bp9Gy26M+iCue63jofVSwmFz1zf66EaHA1PKOJNRgQPFwY+oeDE1U2lQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What problem is this solving?

ATTS, we want to have a clue about the accounts where the requests made to the Checkout API, through this app, don't have `RCSessionIdv7` cookie. 

[context](https://vtex.slack.com/archives/C1FRE8V9A/p1704306141571469)
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
