### PR TITLE
fix: refactoring the logic of adding the subscriptionData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Refactoring the logic of adding the subscriptionData field to the orderForm
+
 ## [0.67.1] - 2024-04-29
 
 ### Changed


### PR DESCRIPTION
#### What problem is this solving?

The current logic for adding subscription items to the cart had a bug in calculating the itemIndex when a promotion added a gift to the cart. Reordering the items array invalidated the previous index calculation, resulting in the subscription data being associated with the wrong item.

#### How should this be manually tested?

To check for the bug, add an item with a promotional offer to the cart and then try adding an item with a subscription. When checking the subscriptionData field, no information will be provided regarding the latter item.

Fix tested in this workspace: https://testvtex--clubsoftysb2c.myvtex.com/jabon-barra-elite-humectante-pack-3-un/p

#### Type of changes

✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

