### PR TITLE
passing the rc cookies forward to checkout api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Forward `VtexRCSessionIdv7` and `VtexRCMacIdv7` cookies to the Checkout API.
+
 ## [0.67.1] - 2024-04-29
 
 ### Changed

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -401,11 +401,13 @@ export class Checkout extends JanusClient {
   }
 
   private getCommonHeaders = () => {
-    const { orderFormId, ownerId } = (this.context as unknown) as CustomIOContext
+    const { orderFormId, ownerId, vtexRCSessionIdv7, vtexRCMacIdv7 } = (this.context as unknown) as CustomIOContext
     const checkoutCookie = orderFormId ? checkoutCookieFormat(orderFormId) : ''
     const ownershipCookie = ownerId ? ownershipCookieFormat(ownerId) : ''
+    const rcSessionCookie = vtexRCSessionIdv7 ? `VtexRCSessionIdv7=${vtexRCSessionIdv7};` : ''
+    const rcMacCookie = vtexRCMacIdv7 ? `VtexRCMacIdv7=${vtexRCMacIdv7};` : ''
     return {
-      Cookie: `${checkoutCookie}${ownershipCookie}vtex_segment=${this.context.segmentToken};vtex_session=${this.context.sessionToken};`,
+      Cookie: `${checkoutCookie}${ownershipCookie}${rcSessionCookie}${rcMacCookie}vtex_segment=${this.context.segmentToken};vtex_session=${this.context.sessionToken};`,
     }
   }
 
@@ -487,6 +489,9 @@ export class Checkout extends JanusClient {
 
 export class CheckoutNoCookies extends Checkout {
   constructor(ctx: IOContext, options?: InstanceOptions) {
-    super({ ...ctx, orderFormId: null, ownerId: null } as any, { ...options, headers: {} })
+    super(
+      { ...ctx, orderFormId: null, ownerId: null, vtexRCSessionIdv7: null, vtexRCMacIdv7: null } as any,
+      { ...options, headers: {} }
+    )
   }
 }

--- a/node/constants/index.ts
+++ b/node/constants/index.ts
@@ -17,3 +17,5 @@ export const DELIVERY = 'delivery'
 export const PICKUP_IN_POINT = 'pickup-in-point'
 
 export const VTEX_SESSION = 'vtex_session'
+export const VTEX_RC_SESSION_COOKIE = 'VtexRCSessionIdv7'
+export const VTEX_RC_MAC_COOKIE = 'VtexRCMacIdv7'

--- a/node/directives/withOrderFormId.ts
+++ b/node/directives/withOrderFormId.ts
@@ -2,6 +2,7 @@ import { defaultFieldResolver, GraphQLField } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
 
 import { getOrderFormIdFromCookie } from '../utils'
+import { VTEX_RC_SESSION_COOKIE, VTEX_RC_MAC_COOKIE } from '../constants'
 
 export class WithOrderFormId extends SchemaDirectiveVisitor {
   public visitFieldDefinition(field: GraphQLField<any, any>) {
@@ -9,6 +10,8 @@ export class WithOrderFormId extends SchemaDirectiveVisitor {
     field.resolve = async (root: any, args: any, ctx: Context, info: any) => {
       const checkoutOrderFormId = getOrderFormIdFromCookie(ctx.cookies)
       ctx.vtex.orderFormId = checkoutOrderFormId
+      ctx.vtex.vtexRCSessionIdv7 = ctx.cookies.get(VTEX_RC_SESSION_COOKIE) ?? ctx.get(VTEX_RC_SESSION_COOKIE)
+      ctx.vtex.vtexRCMacIdv7 = ctx.cookies.get(VTEX_RC_MAC_COOKIE) ?? ctx.get(VTEX_RC_MAC_COOKIE)
       return resolve(root, args, ctx, info)
     }
   }

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -23,6 +23,8 @@ declare global {
     segment?: SegmentData
     orderFormId?: string
     ownerId?: string
+    vtexRCSessionIdv7?: string
+    vtexRCMacIdv7?: string
   }
 
   interface OrderFormMarketingData {


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

This pull request updates the checkout client and related code to support two new cookies, `VtexRCSessionIdv7` and `VtexRCMacIdv7`, by propagating their values through context and including them in outgoing requests. The changes ensure these cookies are consistently handled in both the main checkout client and the no-cookies variant, and introduces constants for these cookie names.

**Checkout client enhancements:**

* Updated the `Checkout` client (`node/clients/checkout.ts`) to read `vtexRCSessionIdv7` and `vtexRCMacIdv7` from context and include them as cookies in the `Cookie` header for outgoing requests.
* Updated the `CheckoutNoCookies` class to explicitly set `vtexRCSessionIdv7` and `vtexRCMacIdv7` to `null` in its context, ensuring no RC cookies are sent in this variant.

**Cookie management and context propagation:**

* In the `WithOrderFormId` GraphQL directive, extracted the `VtexRCSessionIdv7` and `VtexRCMacIdv7` cookies from the incoming request and stored them in the context for downstream usage.

**Constants:**

* Added `VTEX_RC_SESSION_COOKIE` and `VTEX_RC_MAC_COOKIE` constants to `node/constants/index.ts` for standardized cookie name usage throughout the codebase.

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
